### PR TITLE
Rename GITHUB_PERSONAL_ACCESS_TOKEN to GH_TOKEN

### DIFF
--- a/.devcontainer/post-attach.sh
+++ b/.devcontainer/post-attach.sh
@@ -7,8 +7,8 @@ if [ -v CODESPACES ]; then
     if [ ! -v AI_API_TOKEN ]; then
         echo "⚠️ Running in Codespaces - please add AI_API_TOKEN to your Codespaces secrets"
     fi
-    if [ ! -v GITHUB_PERSONAL_ACCESS_TOKEN ]; then
-        echo "⚠️ Running in Codespaces - please add GITHUB_PERSONAL_ACCESS_TOKEN to your Codespaces secrets"
+    if [ ! -v GH_TOKEN ]; then
+        echo "⚠️ Running in Codespaces - please add GH_TOKEN to your Codespaces secrets"
     fi
 fi
 

--- a/src/run_seclab_agent.sh
+++ b/src/run_seclab_agent.sh
@@ -10,4 +10,4 @@ mkdir -p data
 
 docker run -i \
        --mount type=bind,src="$PWD",dst=/app \
-       -e GITHUB_PERSONAL_ACCESS_TOKEN="$GITHUB_PERSONAL_ACCESS_TOKEN" -e AI_API_TOKEN="$AI_API_TOKEN" "ghcr.io/githubsecuritylab/seclab-taskflow-agent" "$@"
+       -e GH_TOKEN="$GH_TOKEN" -e AI_API_TOKEN="$AI_API_TOKEN" "ghcr.io/githubsecuritylab/seclab-taskflow-agent" "$@"

--- a/src/seclab_taskflows/mcp_servers/codeql_python/README.md
+++ b/src/seclab_taskflows/mcp_servers/codeql_python/README.md
@@ -23,7 +23,7 @@ CODEQL_DBS_BASE_PATH="/workspaces/seclab-taskflows/data/codeql_databases" # path
 # Example values for a local setup, run with `python -m seclab_taskflow_agent -t seclab_taskflows.taskflows.audit.remote_sources_local`
 MEMCACHE_STATE_DIR="/workspaces/seclab-taskflows/data" # path to folder for storing the memcache database
 DATA_DIR="/workspaces/seclab-taskflows/data" # path to folder for storing the codeql_sqlite databases and all other data
-GITHUB_PERSONAL_ACCESS_TOKEN= # can be the same token as COPILOT_TOKEN. Or another one, with access e.g. to private repositories
+GH_TOKEN= # can be the same token as COPILOT_TOKEN. Or another one, with access e.g. to private repositories
 CODEQL_CLI= # output of command `find ~ -type f -name codeql -executable 2>/dev/null`
 
 # Example docker env run with ./run_seclab_agent.sh [...]

--- a/src/seclab_taskflows/mcp_servers/gh_actions.py
+++ b/src/seclab_taskflows/mcp_servers/gh_actions.py
@@ -45,7 +45,7 @@ high_privileged_triggers = set(["issues", "issue_comment", "pull_request_comment
 
 unimportant_triggers = set(['pull_request', 'workflow_dispatch'])
 
-GITHUB_PERSONAL_ACCESS_TOKEN = os.getenv('GITHUB_PERSONAL_ACCESS_TOKEN', default='')
+GH_TOKEN = os.getenv('GH_TOKEN', default='')
 
 ACTIONS_DB_DIR = mcp_data_dir('seclab-taskflows', 'gh_actions', 'ACTIONS_DB_DIR')
 
@@ -56,7 +56,7 @@ Base.metadata.create_all(engine, tables = [WorkflowUses.__table__])
 async def call_api(url: str, params: dict, raw = False) -> str:
     """Call the GitHub code scanning API to fetch alert."""
     headers = {"Accept": "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28",
-                          "Authorization": f"Bearer {GITHUB_PERSONAL_ACCESS_TOKEN}"}
+                          "Authorization": f"Bearer {GH_TOKEN}"}
     if raw:
         headers["Accept"] = "application/vnd.github.raw+json"
     async def _fetch(url, headers, params):

--- a/src/seclab_taskflows/mcp_servers/gh_code_scanning.py
+++ b/src/seclab_taskflows/mcp_servers/gh_code_scanning.py
@@ -27,7 +27,7 @@ logging.basicConfig(
 
 mcp = FastMCP("GitHubCodeScanning")
 
-GITHUB_PERSONAL_ACCESS_TOKEN = os.getenv('GITHUB_PERSONAL_ACCESS_TOKEN', default='')
+GH_TOKEN = os.getenv('GH_TOKEN', default='')
 
 CODEQL_DBS_BASE_PATH = mcp_data_dir('seclab-taskflows', 'codeql', 'CODEQL_DBS_BASE_PATH')
 ALERT_RESULTS_DIR = mcp_data_dir('seclab-taskflows', 'gh_code_scanning', 'ALERT_RESULTS_DIR')
@@ -72,7 +72,7 @@ def parse_alert(alert: dict) -> dict:
 async def call_api(url: str, params: dict) -> str | httpx.Response:
     """Call the GitHub code scanning API to fetch alert."""
     headers = {"Accept": "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28",
-                          "Authorization": f"Bearer {GITHUB_PERSONAL_ACCESS_TOKEN}"}
+                          "Authorization": f"Bearer {GH_TOKEN}"}
     async def _fetch_alerts(url, headers, params):
         try:
             async with httpx.AsyncClient(headers = headers) as client:
@@ -182,7 +182,7 @@ async def _fetch_codeql_databases(owner: str, repo: str, language: str):
     """Fetch the CodeQL databases for a given repo and language."""
     url = f"https://api.github.com/repos/{owner}/{repo}/code-scanning/codeql/databases/{language}"
     headers = {"Accept": "application/zip,application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28",
-                          "Authorization": f"Bearer {os.getenv('GITHUB_PERSONAL_ACCESS_TOKEN')}"}
+                          "Authorization": f"Bearer {os.getenv('GH_TOKEN')}"}
     try:
         async with httpx.AsyncClient() as client:
             async with client.stream('GET', url, headers =headers, follow_redirects=True) as response:
@@ -238,7 +238,7 @@ async def dismiss_alert(
     headers = {
         "Accept": "application/vnd.github+json",
         "X-GitHub-Api-Version": "2022-11-28",
-        "Authorization": f"Bearer {GITHUB_PERSONAL_ACCESS_TOKEN}"
+        "Authorization": f"Bearer {GH_TOKEN}"
     }
 
     async with httpx.AsyncClient(headers=headers) as client:

--- a/src/seclab_taskflows/mcp_servers/gh_file_viewer.py
+++ b/src/seclab_taskflows/mcp_servers/gh_file_viewer.py
@@ -43,7 +43,7 @@ class SearchResults(Base):
 
 mcp = FastMCP("GitHubFileViewer")
 
-GITHUB_PERSONAL_ACCESS_TOKEN = os.getenv('GITHUB_PERSONAL_ACCESS_TOKEN', default='')
+GH_TOKEN = os.getenv('GH_TOKEN', default='')
 
 SEARCH_RESULT_DIR = mcp_data_dir('seclab-taskflows', 'gh_file_viewer', 'SEARCH_RESULTS_DIR')
 
@@ -54,7 +54,7 @@ Base.metadata.create_all(engine, tables = [SearchResults.__table__])
 async def call_api(url: str, params: dict) -> str:
     """Call the GitHub code scanning API to fetch alert."""
     headers = {"Accept": "application/vnd.github.raw+json", "X-GitHub-Api-Version": "2022-11-28",
-                          "Authorization": f"Bearer {GITHUB_PERSONAL_ACCESS_TOKEN}"}
+                          "Authorization": f"Bearer {GH_TOKEN}"}
     async def _fetch_file(url, headers, params):
         try:
             async with httpx.AsyncClient(headers = headers) as client:
@@ -79,7 +79,7 @@ async def _fetch_source_zip(owner: str, repo: str, tmp_dir):
     """Fetch the source code."""
     url = f"https://api.github.com/repos/{owner}/{repo}/zipball"
     headers = {"Accept": "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28",
-               "Authorization": f"Bearer {GITHUB_PERSONAL_ACCESS_TOKEN}"}
+               "Authorization": f"Bearer {GH_TOKEN}"}
     try:
         async with httpx.AsyncClient() as client:
             async with client.stream('GET', url, headers =headers, follow_redirects=True) as response:

--- a/src/seclab_taskflows/mcp_servers/local_gh_resources.py
+++ b/src/seclab_taskflows/mcp_servers/local_gh_resources.py
@@ -22,7 +22,7 @@ logging.basicConfig(
 
 mcp = FastMCP("LocalGHResources")
 
-GITHUB_PERSONAL_ACCESS_TOKEN = os.getenv('GITHUB_PERSONAL_ACCESS_TOKEN')
+GH_TOKEN = os.getenv('GH_TOKEN')
 
 LOCAL_GH_DIR = mcp_data_dir('seclab-taskflows', 'local_gh_resources', 'LOCAL_GH_DIR')
 
@@ -45,7 +45,7 @@ def sanitize_file_path(file_path, allow_paths):
 async def call_api(url: str, params: dict) -> str:
     """Call the GitHub code scanning API to fetch alert."""
     headers = {"Accept": "application/vnd.github.raw+json", "X-GitHub-Api-Version": "2022-11-28",
-                          "Authorization": f"Bearer {GITHUB_PERSONAL_ACCESS_TOKEN}"}
+                          "Authorization": f"Bearer {GH_TOKEN}"}
     async def _fetch_file(url, headers, params):
         try:
             async with httpx.AsyncClient(headers = headers) as client:
@@ -67,7 +67,7 @@ async def _fetch_source_zip(owner: str, repo: str, tmp_dir):
     """Fetch the source code."""
     url = f"https://api.github.com/repos/{owner}/{repo}/zipball"
     headers = {"Accept": "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28",
-               "Authorization": f"Bearer {GITHUB_PERSONAL_ACCESS_TOKEN}"}
+               "Authorization": f"Bearer {GH_TOKEN}"}
     try:
         async with httpx.AsyncClient() as client:
             async with client.stream('GET', url, headers =headers, follow_redirects=True) as response:

--- a/src/seclab_taskflows/toolboxes/gh_actions.yaml
+++ b/src/seclab_taskflows/toolboxes/gh_actions.yaml
@@ -10,5 +10,5 @@ server_params:
   command: python
   args: ["-m", "seclab_taskflows.mcp_servers.gh_actions"]
   env:
-    GITHUB_PERSONAL_ACCESS_TOKEN: "{{ env GITHUB_PERSONAL_ACCESS_TOKEN }}"
+    GH_TOKEN: "{{ env GH_TOKEN }}"
     ACTIONS_DB_DIR: "{{ env DATA_DIR }}"

--- a/src/seclab_taskflows/toolboxes/gh_code_scanning.yaml
+++ b/src/seclab_taskflows/toolboxes/gh_code_scanning.yaml
@@ -10,6 +10,6 @@ server_params:
   command: python
   args: ["-m", "seclab_taskflows.mcp_servers.gh_code_scanning"]
   env:
-    GITHUB_PERSONAL_ACCESS_TOKEN: "{{ env GITHUB_PERSONAL_ACCESS_TOKEN }}"
+    GH_TOKEN: "{{ env GH_TOKEN }}"
     CODEQL_DBS_BASE_PATH: "{{ env CODEQL_DBS_BASE_PATH }}"
     ALERT_RESULTS_DIR: "{{ env DATA_DIR }}"

--- a/src/seclab_taskflows/toolboxes/gh_file_viewer.yaml
+++ b/src/seclab_taskflows/toolboxes/gh_file_viewer.yaml
@@ -10,5 +10,5 @@ server_params:
   command: python
   args: ["-m", "seclab_taskflows.mcp_servers.gh_file_viewer"]
   env:
-    GITHUB_PERSONAL_ACCESS_TOKEN: "{{ env GITHUB_PERSONAL_ACCESS_TOKEN }}"
+    GH_TOKEN: "{{ env GH_TOKEN }}"
     SEARCH_RESULTS_DIR: "{{ env DATA_DIR }}"

--- a/src/seclab_taskflows/toolboxes/ghsa.yaml
+++ b/src/seclab_taskflows/toolboxes/ghsa.yaml
@@ -10,4 +10,4 @@ server_params:
   command: python
   args: ["-m", "seclab_taskflows.mcp_servers.ghsa"]
   env:
-    GITHUB_PERSONAL_ACCESS_TOKEN: "{{ env GITHUB_PERSONAL_ACCESS_TOKEN }}"
+    GH_TOKEN: "{{ env GH_TOKEN }}"

--- a/src/seclab_taskflows/toolboxes/local_gh_resources.yaml
+++ b/src/seclab_taskflows/toolboxes/local_gh_resources.yaml
@@ -10,5 +10,5 @@ server_params:
   command: python
   args: ["-m", "seclab_taskflows.mcp_servers.local_gh_resources"]
   env:
-    GITHUB_PERSONAL_ACCESS_TOKEN: "{{ env GITHUB_PERSONAL_ACCESS_TOKEN }}"
+    GH_TOKEN: "{{ env GH_TOKEN }}"
     LOCAL_GH_DIR: "{{ env DATA_DIR }}"


### PR DESCRIPTION
Codespace secrets are not allowed to have a name that starts with "GITHUB".

I ran this command to replace the name everywhere:

```bash
find . -type f -exec sed -i 's/GITHUB_PERSONAL_ACCESS_TOKEN/GH_TOKEN/g' {} \
```

I've made the same change in the other repo: https://github.com/GitHubSecurityLab/seclab-taskflow-agent/pull/114