### PR TITLE
Migrate to Jinja2 template system with semver string versions

### DIFF
--- a/src/seclab_taskflows/configs/model_config.yaml
+++ b/src/seclab_taskflows/configs/model_config.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 seclab-taskflow-agent:
-  version: 1
+  version: "1.0"
   filetype: model_config
 models:
    code_analysis: gpt-5

--- a/src/seclab_taskflows/configs/model_config_codeql_python.yaml
+++ b/src/seclab_taskflows/configs/model_config_codeql_python.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 seclab-taskflow-agent:
-  version: 1
+  version: "1.0"
   filetype: model_config
 models:
    code_analysis: gpt-5

--- a/src/seclab_taskflows/configs/model_config_lowercost.yaml
+++ b/src/seclab_taskflows/configs/model_config_lowercost.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 seclab-taskflow-agent:
-  version: 1
+  version: "1.0"
   filetype: model_config
 models:
    code_analysis: gpt-5-mini

--- a/src/seclab_taskflows/personalities/action_expert.yaml
+++ b/src/seclab_taskflows/personalities/action_expert.yaml
@@ -3,8 +3,7 @@
 
 seclab-taskflow-agent:
   filetype: personality
-  version: 1
-
+  version: "1.0"
 personality: |
   You are an expert in GitHub actions and workflows. A GitHub workflow maybe reusuable by other workflows. 
   Here are some important facts about GitHub actions and workflows that you should know and used in your analysis.

--- a/src/seclab_taskflows/personalities/auditor.yaml
+++ b/src/seclab_taskflows/personalities/auditor.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 seclab-taskflow-agent:
-  version: 1
+  version: "1.0"
   filetype: personality
 
 personality: |

--- a/src/seclab_taskflows/personalities/web_application_security_expert.yaml
+++ b/src/seclab_taskflows/personalities/web_application_security_expert.yaml
@@ -3,8 +3,7 @@
 
 seclab-taskflow-agent:
   filetype: personality
-  version: 1
-
+  version: "1.0"
 personality: |
   You are a security expert for web applications and libraries, in multiple programming languages.
   You have the ability to call tools to aid you in your security reviews. You know when libraries are used in an unsafe way.

--- a/src/seclab_taskflows/prompts/audit/audit_issue.yaml
+++ b/src/seclab_taskflows/prompts/audit/audit_issue.yaml
@@ -3,8 +3,7 @@
 
 seclab-taskflow-agent:
   filetype: prompt
-  version: 1
-
+  version: "1.0"
 prompt: |
         The issues suggested have not been properly verified and are only suggested because they are common issues in these types of 
         application. Your task is to audit the source code to check if this type of issues is present. 

--- a/src/seclab_taskflows/prompts/triage_taskflows/actions_common/check_dismiss_reason.yaml
+++ b/src/seclab_taskflows/prompts/triage_taskflows/actions_common/check_dismiss_reason.yaml
@@ -3,21 +3,20 @@
 
 seclab-taskflow-agent:
   filetype: prompt
-  version: 1
-
+  version: "1.0"
 prompt: |
-  The key is {{ RESULT_key }}. If it is `repos` or `dismissed_alerts_summary,` then your task is done.
+  The key is {{ result.key }}. If it is `repos` or `dismissed_alerts_summary,` then your task is done.
 
-  The repo and alert id can are encoded in the key {{ RESULT_key }} as follows:
+  The repo and alert id can are encoded in the key {{ result.key }} as follows:
   ```
   <encoded_repo_name>_<alert id>
   ```
   For example, if the key is `my_org/my_repo_123`, the repo name to use is `my_org/my_repo`.
   The alert id is the number after the last `_` in the key, which is `123` in this case.
 
-  Before you start, check if an issue with the alert id already exists in {{ RESULT_repo }}.
+  Before you start, check if an issue with the alert id already exists in {{ result.repo }}.
   If it doesn't, then your task is done. 
-  Otherwise, fetch the issue from {{ RESULT_repo }} using the issue id that you found and inspect its body.
+  Otherwise, fetch the issue from {{ result.repo }} using the issue id that you found and inspect its body.
   Remember the issue id, which you'll need to add label and comment on the issue later. 
   This is usually not the same as the alert id.
 

--- a/src/seclab_taskflows/prompts/triage_taskflows/actions_common/dismiss_decision.yaml
+++ b/src/seclab_taskflows/prompts/triage_taskflows/actions_common/dismiss_decision.yaml
@@ -3,8 +3,7 @@
 
 seclab-taskflow-agent:
   filetype: prompt
-  version: 1
-
+  version: "1.0"
 prompt: |
   If you decided that the ANY dismissal reason applies then alert is invalid. In this case, add the `FP` label to the issue.
   But if the None of the dismissal reason applies, then don't add the `FP` label.

--- a/src/seclab_taskflows/taskflows/alert_triage_examples/triage_common/check_notes.yaml
+++ b/src/seclab_taskflows/taskflows/alert_triage_examples/triage_common/check_notes.yaml
@@ -3,8 +3,7 @@
 
 seclab-taskflow-agent:
   filetype: taskflow
-  version: 1
-
+  version: "1.0"
 model_config: seclab_taskflows.configs.model_config
 
 taskflow:
@@ -17,10 +16,10 @@ taskflow:
         - seclab_taskflows.personalities.web_application_security_expert
       async: true
       user_prompt: |
-        The alert_id is {{ RESULT_alert_id }} and the repo is {{ RESULT_repo }}.
+        The alert_id is {{ result.alert_id }} and the repo is {{ result.repo }}.
         The notes from the alert analysis is:        
         ```
-        {{ RESULT_result }}
+        {{ result.result }}
         ```
         Check all results whether they contain next steps that need to be taken. If they do, then take those steps.
         In case code parts (such as methods) were not found previously, look them up and change the notes accordingly.

--- a/src/seclab_taskflows/taskflows/alert_triage_examples/triage_common/fetch_code_scanning_alerts.yaml
+++ b/src/seclab_taskflows/taskflows/alert_triage_examples/triage_common/fetch_code_scanning_alerts.yaml
@@ -3,8 +3,7 @@
 
 seclab-taskflow-agent:
   filetype: taskflow
-  version: 1
-
+  version: "1.0"
 model_config: seclab_taskflows.configs.model_config
 
 taskflow:
@@ -16,7 +15,7 @@ taskflow:
       agents:
         - seclab_taskflow_agent.personalities.assistant
       user_prompt: |
-        Fetch the open alerts from the {{ RESULT_repo }} repo to the sql database.
-        Use {{ RESULT_repo }} as the repo name for storing.
+        Fetch the open alerts from the {{ result.repo }} repo to the sql database.
+        Use {{ result.repo }} as the repo name for storing.
       toolboxes:
         - seclab_taskflows.toolboxes.gh_code_scanning

--- a/src/seclab_taskflows/taskflows/alert_triage_examples/triage_common/reachability_analysis.yaml
+++ b/src/seclab_taskflows/taskflows/alert_triage_examples/triage_common/reachability_analysis.yaml
@@ -3,8 +3,7 @@
 
 seclab-taskflow-agent:
   filetype: taskflow
-  version: 1
-
+  version: "1.0"
 model_config: seclab_taskflows.configs.model_config
 
 taskflow:
@@ -15,18 +14,18 @@ taskflow:
       model: triage
       max_steps: 40
       user_prompt: |
-        Inspect the alert location at {{ RESULT_location }} in the repo {{ RESULT_repo }}.
-        This is an alert for a {{ INPUTS_type }} vulnerability.
+        Inspect the alert location at {{ result.location }} in the repo {{ result.repo }}.
+        This is an alert for a {{ inputs.type }} vulnerability.
 
         ## Sanitizers
         For type of vulnerability, you should consider the following as sanitizer:
 
-        {{ INPUTS_sanitizer }}
+        {{ inputs.sanitizer }}
 
         ## User controlled inputs
 
         In this task. You need to determine whether data relevant to the alert can be controlled by an untrusted user.
-        {{ INPUTS_user_input }}
+        {{ inputs.user_input }}
 
         Create a call graph to understand how the code flows from the entry point to the vulnerable code. Let's think step by step and go through the call graph.
         Always try to find out whether the code is in use and reachable from the outside (e.g. via HTTP request).
@@ -36,7 +35,7 @@ taskflow:
 
         You need to record each step of your analysis in the note, stating which function is passing on the alert data and 
         note any sanitizer that is used. Update the results field of the alert result with your notes using `update_alert_result` with 
-        {{ RESULT_alert_id }} as alert_id and {{ RESULT_repo }} as repo.
+        {{ result.alert_id }} as alert_id and {{ result.repo }} as repo.
 
         ## Sanitizer found
         If at any point, you find that the data is sufficiently sanitized, you should mark the alert as invalid, and update its

--- a/src/seclab_taskflows/taskflows/alert_triage_examples/triage_common/validate_user_input.yaml
+++ b/src/seclab_taskflows/taskflows/alert_triage_examples/triage_common/validate_user_input.yaml
@@ -3,8 +3,7 @@
 
 seclab-taskflow-agent:
   filetype: taskflow
-  version: 1
-
+  version: "1.0"
 model_config: seclab_taskflows.configs.model_config
 
 taskflow:
@@ -14,10 +13,10 @@ taskflow:
       async: true
       model: triage
       user_prompt: |
-        The alert_id is {{ RESULT_alert_id }} and the repo is {{ RESULT_repo }}.
+        The alert_id is {{ result.alert_id }} and the repo is {{ result.repo }}.
         The notes from the alert analysis is:        
         ```
-        {{ RESULT_result }}
+        {{ result.result }}
         ```
         Check that the notes contains a section call "User-Controlled input" or similar.
         If the section is missing, then mark the alert as invalid and update the alert results

--- a/src/seclab_taskflows/taskflows/alert_triage_examples/triage_taskflows/actions_common/audit_workflow_users.yaml
+++ b/src/seclab_taskflows/taskflows/alert_triage_examples/triage_taskflows/actions_common/audit_workflow_users.yaml
@@ -3,8 +3,7 @@
 
 seclab-taskflow-agent:
   filetype: taskflow
-  version: 1
-
+  version: "1.0"
 model_config: seclab_taskflows.configs.model_config
 
 taskflow:
@@ -16,27 +15,27 @@ taskflow:
       agents:
         - seclab_taskflows.personalities.action_expert
       user_prompt: |
-        Fetch the file {{ RESULT_user }} from the repo {{ RESULT_repo }}.
+        Fetch the file {{ result.user }} from the repo {{ result.repo }}.
         
-        Get the high privileged triggers for the of the workflow in the file {{ RESULT_user }} and check if it is reusable. 
+        Get the high privileged triggers for the of the workflow in the file {{ result.user }} and check if it is reusable. 
         If it does not contain any high privileged trigger AND it is not a reusable action, then the task is done.
 
-        Otherwise, check that the action specified by {{ RESULT_user }} in repo {{ RESULT_repo }} is active.
-        To do so, fetch the workflow from GitHub using the `workflow_id` derived from {{ RESULT_user }}.
+        Otherwise, check that the action specified by {{ result.user }} in repo {{ result.repo }} is active.
+        To do so, fetch the workflow from GitHub using the `workflow_id` derived from {{ result.user }}.
         Then check the workflow state, if it is not `active`, then the task is done.
 
-        Otherwise, from the file {{ RESULT_user }}, take note of the following:
-        1. All the triggers of the action {{ RESULT_user }}.
-        2. All the high privileged triggers of {{ RESULT_user }}, if any. You must clearly state that these are high privileged triggers.
-        2. Any permissions granted to the {{ RESULT_user }} action.
-        3. Any secrets used in the {{ RESULT_user }} action.
+        Otherwise, from the file {{ result.user }}, take note of the following:
+        1. All the triggers of the action {{ result.user }}.
+        2. All the high privileged triggers of {{ result.user }}, if any. You must clearly state that these are high privileged triggers.
+        2. Any permissions granted to the {{ result.user }} action.
+        3. Any secrets used in the {{ result.user }} action.
 
         Update the notes and alert results as follows:
-        You must mention the fact that {{ RESULT_user }} uses {{ RESULT_action }} in lines {{ RESULT_lines }}
+        You must mention the fact that {{ result.user }} uses {{ result.action }} in lines {{ result.lines }}
         in the notes.
-        You must also include all the permissions granted to the {{ RESULT_user }} action in the notes, and all the triggers of the action.
-        Finally, update the all the alert result that has {{ RESULT_action }} with the results in your notes using `update_all_alert_results_for_flow_graph` with 
-        your notes as the `results`, {{ RESULT_action }} as the `next` and {{ RESULT_repo }} as the `repo`.
+        You must also include all the permissions granted to the {{ result.user }} action in the notes, and all the triggers of the action.
+        Finally, update the all the alert result that has {{ result.action }} with the results in your notes using `update_all_alert_results_for_flow_graph` with 
+        your notes as the `results`, {{ result.action }} as the `next` and {{ result.repo }} as the `repo`.
       toolboxes:
         - seclab_taskflows.toolboxes.gh_file_viewer
         - seclab_taskflows.toolboxes.report_alert_state

--- a/src/seclab_taskflows/taskflows/alert_triage_examples/triage_taskflows/actions_common/check_report.yaml
+++ b/src/seclab_taskflows/taskflows/alert_triage_examples/triage_taskflows/actions_common/check_report.yaml
@@ -3,8 +3,7 @@
 
 seclab-taskflow-agent:
   filetype: taskflow
-  version: 1
-
+  version: "1.0"
 model_config: seclab_taskflows.configs.model_config
 
 taskflow:
@@ -18,9 +17,9 @@ taskflow:
       user_prompt: |
         The bug report is as follows:
         ```
-        {{ RESULT_value }}
+        {{ result.value }}
         ```
-        The alert_id and repo are encoded in the key {{ RESULT_key }} as
+        The alert_id and repo are encoded in the key {{ result.key }} as
         `<repo_name>_<alert_id>`. Use this to extract the alert_id and repo_name from the key. 
 
         If the alert has a high privileged trigger, then the alert is valid and your task is done. Do nothing and DO NOT continue with the task and
@@ -38,23 +37,23 @@ taskflow:
           In this case, check that the report contains a section that lists the vulnerable action users. 
           If there isn't any vulnerable action users and there is no high privileged trigger, 
           then mark the alert as invalid and 
-          using the alert_id and repo, then remove the memcache entry with the key {{ RESULT_key }}.
+          using the alert_id and repo, then remove the memcache entry with the key {{ result.key }}.
         - If it is a reusable action and contains a section that lists the vulnerable action users, then check 
           if any of the action user is a high privileged workflow. If none of the the action users is a high privileged workflow, 
-          then mark the alert as invalid and remove the memcache entry with the key {{ RESULT_key }}.
+          then mark the alert as invalid and remove the memcache entry with the key {{ result.key }}.
         - Is there any mentioning of `write` permissions or secrets used by the action? If neither are mentioned, and none of the triggers is 
-          a high privileged trigger, then mark the alert as invalid and remove the memcache entry with the key {{ RESULT_key }}.
+          a high privileged trigger, then mark the alert as invalid and remove the memcache entry with the key {{ result.key }}.
         - Is the only trigger of the alert `workflow_call` or `pull_request`? If so, and there is no mentioning of any 
-          `write` permission granted, then mark the alert as invalid and remove the memcache entry with the key {{ RESULT_key }}.
+          `write` permission granted, then mark the alert as invalid and remove the memcache entry with the key {{ result.key }}.
 
-        {{ INPUTS_vuln_specifics }}
+        {{ inputs.vuln_specifics }}
 
         IMPORTANT:
         If any of the above indicates that the alert is invalid,
-        then you MUST mark the alert as invalid and remove the memcache entry with the key {{ RESULT_key }}, even if you believe 
+        then you MUST mark the alert as invalid and remove the memcache entry with the key {{ result.key }}, even if you believe 
         the vulnerability still poses a risk. You MUST follow the instructions. You can then finish the task.
         You should then also update the alert result with the reason why the alert is invalid, using the alert_id and repo_name extracted 
-        from the key {{ RESULT_key }}.
+        from the key {{ result.key }}.
         
       toolboxes:
         - seclab_taskflow_agent.toolboxes.memcache

--- a/src/seclab_taskflows/taskflows/alert_triage_examples/triage_taskflows/actions_common/cleanup_results.yaml
+++ b/src/seclab_taskflows/taskflows/alert_triage_examples/triage_taskflows/actions_common/cleanup_results.yaml
@@ -3,8 +3,7 @@
 
 seclab-taskflow-agent:
   filetype: taskflow
-  version: 1
-
+  version: "1.0"
 model_config: seclab_taskflows.configs.model_config
 
 taskflow:
@@ -16,7 +15,7 @@ taskflow:
       name: set up taskflow
       description: Clearing previous results.
       user_prompt: |
-        Clear the alert results from with the rule `{{ GLOBALS_rule }}` and all the alert flows.
+        Clear the alert results from with the rule `{{ globals.rule }}` and all the alert flows.
         Then clear the memcache.
       toolboxes:
         - seclab_taskflows.toolboxes.report_alert_state

--- a/src/seclab_taskflows/taskflows/alert_triage_examples/triage_taskflows/actions_common/collect_dismiss_reasons.yaml
+++ b/src/seclab_taskflows/taskflows/alert_triage_examples/triage_taskflows/actions_common/collect_dismiss_reasons.yaml
@@ -3,8 +3,7 @@
 
 seclab-taskflow-agent:
   filetype: taskflow
-  version: 1
-
+  version: "1.0"
 model_config: seclab_taskflows.configs.model_config
 
 taskflow:
@@ -14,9 +13,9 @@ taskflow:
       agents:
         - seclab_taskflows.personalities.action_expert
       user_prompt: |
-        Fetch the dismissed alerts from the {{ INPUTS_repos }} and use {{ INPUTS_rule }}.
+        Fetch the dismissed alerts from the {{ inputs.repos }} and use {{ inputs.rule }}.
 
-        Look through the dismissal comments and only consider comments that starts with {{ INPUTS_label }}.
+        Look through the dismissal comments and only consider comments that starts with {{ inputs.label }}.
 
         Additionally, include the following dismissal reasons:
         1. There is a check to ensure that vulnerable code only runs when a label is present on the PR.
@@ -24,7 +23,7 @@ taskflow:
         3. There is a check to ensure that the vulnerable code is run in an environment that requires extra approval, such as a production environment.
         4. There is a check to ensure that vulnerable code only runs when the workflow is triggered by an event that is not controlled by the user, 
            such as a push event or a merge event.
-        {{ INPUTS_vuln_specifics }}
+        {{ inputs.vuln_specifics }}
 
         Summarize the reasons for dismissal in a single markdown formatted text block, without mentioning the alert id, rule or the repo name.
         Store the summary in the memcache with the key `dismissed_alerts_summary`.

--- a/src/seclab_taskflows/taskflows/alert_triage_examples/triage_taskflows/actions_common/create_report.yaml
+++ b/src/seclab_taskflows/taskflows/alert_triage_examples/triage_taskflows/actions_common/create_report.yaml
@@ -3,8 +3,7 @@
 
 seclab-taskflow-agent:
   filetype: taskflow
-  version: 1
-
+  version: "1.0"
 model_config: seclab_taskflows.configs.model_config
 
 taskflow:
@@ -16,10 +15,10 @@ taskflow:
       agents:
         - seclab_taskflows.personalities.action_expert
       user_prompt: |
-        The alert_id is {{ RESULT_alert_id }} and the repo is {{ RESULT_repo }}.
+        The alert_id is {{ result.alert_id }} and the repo is {{ result.repo }}.
         The notes from the alert analysis is:        
         ```
-        {{ RESULT_result }}
+        {{ result.result }}
         ```
 
         You now need to create a report based on the analysis of the alert.
@@ -28,16 +27,16 @@ taskflow:
         do not analyze the files, only use it to retrieve code snippets to be included in the report.
         You should also replace the word alert with vulnerability in the report. 
 
-        First determine the file path and repository of the alert from the alert location {{ RESULT_location }}.
+        First determine the file path and repository of the alert from the alert location {{ result.location }}.
         The location may indicate an external file path in a different repo.
-        Inspect the alert location at {{ RESULT_location }} in the repo {{ RESULT_repo }} to determine if it is in an external action or not.
+        Inspect the alert location at {{ result.location }} in the repo {{ result.repo }} to determine if it is in an external action or not.
         If the file path starts with `.github/workflows/external/`, then it is an external action. In this case, 
         extract the actual repository from the file path, which is encoded as follows:
         The file path is in the format `.github/workflows/external/<repo_owner>/<repo_name>/<actual_file_path>`.
         In this case, the actual repository `<repo_owner>/<repo_name>` and the file path is `<actual_file_path>`, 
-        Otherwise, it is an internal action that is in {{ RESULT_repo }} with the expected file path.
+        Otherwise, it is an internal action that is in {{ result.repo }} with the expected file path.
 
-        {{ INPUTS_vul_specifics }}
+        {{ inputs.vul_specifics }}
 
         Next, take a look at the use of secrets from the notes. Again, include code snippets from the action file that contains the use of secrets in the notes.
         If any secrets is used, then state in your report that the code execution identified in the previous step may then lead to the secrets being leaked.
@@ -73,7 +72,7 @@ taskflow:
 
         If the use has a high privileged trigger, then do the following:
         The notes will contain the line number where the reusable action is used.
-        In the report, state that the user action uses the {{ RESULT_location }} action and include the line number where it is used.
+        In the report, state that the user action uses the {{ result.location }} action and include the line number where it is used.
         Then include any permission or secret used by the user action in the report, if any.
 
         If that is the case, and there is no extra permissions granted either to the action or its users, 
@@ -81,18 +80,18 @@ taskflow:
 
         The title of the report should be something like:
         ```
-        ## {{ INPUTS_title }}
+        ## {{ inputs.title }}
         ```
 
         The first sentence of the report must contain the alert id and the repo, like:
 
         ```
-        This report is for the alert with id {{ RESULT_alert_id }} in the repository {{ RESULT_repo }}.
+        This report is for the alert with id {{ result.alert_id }} in the repository {{ result.repo }}.
         ```
 
         Include either privileged context or secret leak in the title based on the analysis of the alert.
         The report should be in markdown format.
-        When you are done, create a memcache entry with the {{ RESULT_repo }}_{{ RESULT_alert_id }} as the key and the report as the value, and store it.
+        When you are done, create a memcache entry with the {{ result.repo }}_{{ result.alert_id }} as the key and the report as the value, and store it.
 
         IMPORTANT:
         For each statement related to code, you must include the line number where the code is located in the file.

--- a/src/seclab_taskflows/taskflows/alert_triage_examples/triage_taskflows/actions_common/review_report.yaml
+++ b/src/seclab_taskflows/taskflows/alert_triage_examples/triage_taskflows/actions_common/review_report.yaml
@@ -3,8 +3,7 @@
 
 seclab-taskflow-agent:
   filetype: taskflow
-  version: 1
-
+  version: "1.0"
 model_config: seclab_taskflows.configs.model_config
 
 taskflow:
@@ -16,9 +15,9 @@ taskflow:
       agents:
         - seclab_taskflows.personalities.action_expert
       user_prompt: |
-        This alert has has alert_id {{ RESULT_alert_id }} and repo {{ RESULT_repo }}. The notes of this alert is: 
+        This alert has has alert_id {{ result.alert_id }} and repo {{ result.repo }}. The notes of this alert is: 
         ```
-        {{ RESULT_result }}
+        {{ result.result }}
         ```
         Your task is to check that the notes is consistent. Do not trust the conclusion of the notes, but inspect the notes and check
         for the validity criteria. Once you have determined the validity of the alert, set the validity of the alert with a tool call and 
@@ -33,26 +32,26 @@ taskflow:
         then that decision is final. You must stop at once and conclude the validity of the alert based on that criteria and 
         set the validity of the alert accordingly.
 
-        {{ INPUTS_vuln_specifics }}
+        {{ inputs.vuln_specifics }}
 
         First check for trigger of the alert in the notes.
-        1. If the alert location {{ RESULT_location }} is a high privileged workflow according to `get_high_privileged_workflow_triggers`, then 
+        1. If the alert location {{ result.location }} is a high privileged workflow according to `get_high_privileged_workflow_triggers`, then 
         the alert is valid.
         2. If the ONLY alert trigger is `workflow_dispatch`, then it is invalid.
-        3. If the alert location {{ RESULT_location }} is not a reusable action, and the `get_high_privileged_workflow_triggers` says it is
+        3. If the alert location {{ result.location }} is not a reusable action, and the `get_high_privileged_workflow_triggers` says it is
         not high privileged, then it is invalid.
-        4. If the alert location {{ RESULT_location }} is not a reusable action, then check that the workflow is active.
+        4. If the alert location {{ result.location }} is not a reusable action, then check that the workflow is active.
            If it is not active, then the alert is invalid.
         5. Check that the workflow is active using the 
-        `fetch_workflow` tool with the actual repository and workflow_id derived from the file path {{ RESULT_location }}.
+        `fetch_workflow` tool with the actual repository and workflow_id derived from the file path {{ result.location }}.
         If it is not `active`, then the alert is invalid.
 
-        If the alert location {{ RESULT_location }} is not a reusable action, but the `get_high_privileged_workflow_triggers`
+        If the alert location {{ result.location }} is not a reusable action, but the `get_high_privileged_workflow_triggers`
         indicates the alert is high privileged, then the alert is valid.
 
         Only Do the following if the alert is in a reusable action. If the alert is not reusable, then the task is done.
 
-        If the alert location {{ RESULT_location }} is a reusable action, then you should check if the action is used in any other workflow.
+        If the alert location {{ result.location }} is a reusable action, then you should check if the action is used in any other workflow.
         IMPORTANT:
         If the alert is a reusable action, then even if it contains a high privileged trigger, you should still
         consider it as a reusable action and check for its users.
@@ -81,7 +80,7 @@ taskflow:
         is high privileged  AND the workflow itself is not high privileged, then the alert is invalid. Mark the alert as invalid and update the "Reviewer analysis" section of the alert result
         with the reason why the alert is invalid.
 
-        When you are done, set the `valid` field of the alert result according to your analysis using alert_id {{ RESULT_alert_id }} and repo {{ RESULT_repo }}.
+        When you are done, set the `valid` field of the alert result according to your analysis using alert_id {{ result.alert_id }} and repo {{ result.repo }}.
       toolboxes:
         - seclab_taskflows.toolboxes.report_alert_state
         - seclab_taskflows.toolboxes.gh_actions

--- a/src/seclab_taskflows/taskflows/alert_triage_examples/triage_taskflows/actions_common/track_workflow_users.yaml
+++ b/src/seclab_taskflows/taskflows/alert_triage_examples/triage_taskflows/actions_common/track_workflow_users.yaml
@@ -3,8 +3,7 @@
 
 seclab-taskflow-agent:
   filetype: taskflow
-  version: 1
-
+  version: "1.0"
 model_config: seclab_taskflows.configs.model_config
 
 taskflow:
@@ -16,20 +15,20 @@ taskflow:
         - seclab_taskflows.personalities.action_expert
       model: triage
       user_prompt: |
-        The alert_id is {{ RESULT_alert_id }} and the repo is {{ RESULT_repo }}.
+        The alert_id is {{ result.alert_id }} and the repo is {{ result.repo }}.
         
-        Check that if the workflow in the alert location {{ RESULT_location }} is an reusuable action. Remember to 
+        Check that if the workflow in the alert location {{ result.location }} is an reusuable action. Remember to 
         check if the location is an external action, and use the appropriate repository and file path to check if it is a reusable action.
         
         If the alert location is not an reusable action, then you are done.
         Otherwise, use the `get_workflow_user` tool to find the users of the reusable action and save the results to database. Use 
-        {{ RESULT_repo }} as the repository regardless of whether the action is an external action or not, because 
-        we are looking for the use of the action in {{ RESULT_repo }} rather than the actual repository. 
-        Use the file path of the location {{ RESULT_location }} as the workflow file path. You do not need to 
+        {{ result.repo }} as the repository regardless of whether the action is an external action or not, because 
+        we are looking for the use of the action in {{ result.repo }} rather than the actual repository. 
+        Use the file path of the location {{ result.location }} as the workflow file path. You do not need to 
         decode the file path when using `get_workflow_user`, it will handle that for you.
 
-        Finally, add an alert flow entry for the alert with the alert_canonical_id {{ RESULT_canonical_id }},
-        the repo {{ RESULT_repo }},
+        Finally, add an alert flow entry for the alert with the alert_canonical_id {{ result.canonical_id }},
+        the repo {{ result.repo }},
         the alert location file path WITHOUT the line numbers as the `next`, a wildcard "*" as `prev`, and a wildcard "*" as `flow_data`.
 
       toolboxes:

--- a/src/seclab_taskflows/taskflows/alert_triage_examples/triage_taskflows/actions_common/trigger_analysis.yaml
+++ b/src/seclab_taskflows/taskflows/alert_triage_examples/triage_taskflows/actions_common/trigger_analysis.yaml
@@ -3,8 +3,7 @@
 
 seclab-taskflow-agent:
   filetype: taskflow
-  version: 1
-
+  version: "1.0"
 model_config: seclab_taskflows.configs.model_config
 
 taskflow:
@@ -17,8 +16,8 @@ taskflow:
       async: true
       user_prompt: |
         You must first make sure that the workflow containing the alert is active. You can do this by using the `check_workflow_active` tool with
-        the actual repository and workflow_id derived from the file path {{ RESULT_location }}.
-        If it is not `active`, then the set the `valid` field of the alert result to `false` using alert_id {{ RESULT_alert_id }} and repo {{ RESULT_repo }}
+        the actual repository and workflow_id derived from the file path {{ result.location }}.
+        If it is not `active`, then the set the `valid` field of the alert result to `false` using alert_id {{ result.alert_id }} and repo {{ result.repo }}
         and update the alert result with the reason that the action is not active and set the `valid` field of the alert to false. 
         If the workflow is not active, then your task is done. Do not continue with the task.
 
@@ -52,7 +51,7 @@ taskflow:
         Store your notes in the `results` field of the alert result by updating the alert results.
         For secrets, include the name of the secret and the line number where it is used in the notes.
 
-        When you are done, set the `valid` field of the alert result to `true` using alert_id {{ RESULT_alert_id }} and repo {{ RESULT_repo }}
+        When you are done, set the `valid` field of the alert result to `true` using alert_id {{ result.alert_id }} and repo {{ result.repo }}
         if the alert is a potential vulnerability, otherwise set it to `false`. 
 
         IMPORTANT:

--- a/src/seclab_taskflows/taskflows/alert_triage_examples/triage_taskflows/create_issues_actions.yaml
+++ b/src/seclab_taskflows/taskflows/alert_triage_examples/triage_taskflows/create_issues_actions.yaml
@@ -3,8 +3,7 @@
 
 seclab-taskflow-agent:
   filetype: taskflow
-  version: 1
-
+  version: "1.0"
 globals:
   rule: actions/untrusted-checkout/critical
 
@@ -20,7 +19,7 @@ taskflow:
         - seclab_taskflow_agent.personalities.assistant
       exclude_from_context: true
       user_prompt: |
-        Fetch all the invalid alert results that have the rule `{{ GLOBALS_rule }}`.
+        Fetch all the invalid alert results that have the rule `{{ globals.rule }}`.
       toolboxes:
         - seclab_taskflows.toolboxes.report_alert_state
   - task:
@@ -37,20 +36,20 @@ taskflow:
       user_prompt: |
         The alert results is the following:
         ```
-        {{ RESULT_result }}
+        {{ result.result }}
         ```
 
         Look for a section called "Reviewer analysis" in the alert results. If the section is not present, then your task is done.
 
-        Otherwise, dismiss the alert using the alert id {{ RESULT_alert_id }}. 
+        Otherwise, dismiss the alert using the alert id {{ result.alert_id }}. 
 
-        The repository is {{ RESULT_repo }}.
+        The repository is {{ result.repo }}.
 
         Dismiss the alert using the "Reviewer analysis" section as the dismissal reason. Summarize the section and remove any duplicate
         information. You need to summarize the reason so that it contains less than 280 characters, otherwise, the dismissal will fail.
         If that happens, then you need to summarize the section again until it is less than 280 characters and try dismissing the alert again.
 
-        Finally, set the completed field of the alert result to true, using the alert_id {{ RESULT_alert_id }}.
+        Finally, set the completed field of the alert result to true, using the alert_id {{ result.alert_id }}.
 
         Do not make any other changes to the alert result.
       toolboxes:
@@ -65,7 +64,7 @@ taskflow:
         - seclab_taskflow_agent.personalities.assistant
       exclude_from_context: true
       user_prompt: |
-        Fetch the all the completed alert results from that has the rule `{{ GLOBALS_rule }}`.
+        Fetch the all the completed alert results from that has the rule `{{ globals.rule }}`.
       toolboxes:
         - seclab_taskflows.toolboxes.report_alert_state
   - task:
@@ -79,17 +78,17 @@ taskflow:
       repeat_prompt: true
       async: true
       user_prompt: |
-        The alert_id is {{ RESULT_alert_id }}. The repository is {{ RESULT_repo }}.
+        The alert_id is {{ result.alert_id }}. The repository is {{ result.repo }}.
 
-        The validity of the alert is {{ RESULT_valid }}. If the alert is valid, then your task is done.
+        The validity of the alert is {{ result.valid }}. If the alert is valid, then your task is done.
         If the alert is not valid, then do the following:
 
-        First check if an issue with the alert id already exists in {{ RESULT_repo }}.
+        First check if an issue with the alert id already exists in {{ result.repo }}.
         If it does, then do not create a new issue and your task is done.
 
-        Otherwise, create an issue in {{ RESULT_repo }} using these notes:
+        Otherwise, create an issue in {{ result.repo }} using these notes:
         ```
-        {{ RESULT_result }}
+        {{ result.result }}
         ```
         Remove any duplicate information of the notes and use it as the issue body.
         The title of the issue should be:
@@ -146,7 +145,7 @@ taskflow:
       agents:
         - seclab_taskflows.personalities.action_expert
       user_prompt: |
-        The repo and alert id can are encoded in the key {{ RESULT_key }} as follows:
+        The repo and alert id can are encoded in the key {{ result.key }} as follows:
         ```
         <encoded_repo_name>_<alert id>
         ```
@@ -155,7 +154,7 @@ taskflow:
 
         Create an issue in the repo using the following as the issue body:
         ```
-        {{ RESULT_value }}
+        {{ result.value }}
         ```
         The issue body should be formatted in markdown.
 
@@ -181,6 +180,6 @@ taskflow:
         - seclab_taskflow_agent.personalities.assistant
       exclude_from_context: true
       user_prompt: |
-        Fetch the all the invalid alert results from that has the rule `{{ GLOBALS_rule }}`.
+        Fetch the all the invalid alert results from that has the rule `{{ globals.rule }}`.
       toolboxes:
         - seclab_taskflows.toolboxes.report_alert_state

--- a/src/seclab_taskflows/taskflows/alert_triage_examples/triage_taskflows/create_issues_js_ts.yaml
+++ b/src/seclab_taskflows/taskflows/alert_triage_examples/triage_taskflows/create_issues_js_ts.yaml
@@ -3,8 +3,7 @@
 
 seclab-taskflow-agent:
   filetype: taskflow
-  version: 1
-
+  version: "1.0"
 model_config: seclab_taskflows.configs.model_config
 
 taskflow:
@@ -41,14 +40,14 @@ taskflow:
       agents:
         - seclab_taskflows.personalities.web_application_security_expert
       user_prompt: |
-        The alert_id is {{ RESULT_alert_id }}. The repository name is {{ RESULT_repo }}
+        The alert_id is {{ result.alert_id }}. The repository name is {{ result.repo }}
 
-        First check if an open issue with the alert id already exists in {{ RESULT_repo }}.
+        First check if an open issue with the alert id already exists in {{ result.repo }}.
         If it does, then do not create a new issue and your task is done.
 
-        Otherwise, create an issue in {{ RESULT_repo }} using these notes:
+        Otherwise, create an issue in {{ result.repo }} using these notes:
         ```
-        {{ RESULT_result }}
+        {{ result.result }}
         ```
         Remove any duplicate information of the notes and use it as the issue body.
         The issue body should be formatted in markdown.
@@ -58,14 +57,14 @@ taskflow:
         - A list of entries with the factors that make the alert an exploitable vulnerability. Prepend each entry with a bullet point, followed by the :heavy_plus_sign: emoji.
         - Another list of entries with the factors that render the vulnerability of the alert not exploitable. Prepend each entry with a bullet point, followed by the :heavy_minus_sign: emoji.
 
-        If references to source code locations are present in the notes, link them like this: https://github.com/{{ RESULT_repo }}/blob/master/{{ RESULT_file_path }}#L{{ RESULT_line_number }}). Remove any occurences of `'` from that link.
+        If references to source code locations are present in the notes, link them like this: https://github.com/{{ result.repo }}/blob/master/{{ result.file_path }}#L{{ result.line_number }}). Remove any occurences of `'` from that link.
 
-        At the bottom of the issue body create a link to the alert like this: https://github.com/{{ RESULT_repo }}/security/code-scanning/{{ RESULT_alert_id }}, name the link `Code scanning alert #{{ RESULT_alert_id }}`. Remove any occurences of `'` from that link.
+        At the bottom of the issue body create a link to the alert like this: https://github.com/{{ result.repo }}/security/code-scanning/{{ result.alert_id }}, name the link `Code scanning alert #{{ result.alert_id }}`. Remove any occurences of `'` from that link.
         Then add following text to the issue body: 🤖 I'm a robot beep boop.
         
         The title of the issue should be:
         ```
-        Code scanning alert #{{ RESULT_alert_id }} triage report for {{ RESULT_rule }}. Remove any occurences of `'` from the rule.
+        Code scanning alert #{{ result.alert_id }} triage report for {{ result.rule }}. Remove any occurences of `'` from the rule.
         ```
         Use `barry-agent` as the label for the issue.
       toolboxes:
@@ -95,14 +94,14 @@ taskflow:
       description: |
         Create GitHub issue for FP alerts and label it with FP.
       user_prompt: |
-        The alert_id is {{ RESULT_alert_id }}. The repository name is {{ RESULT_repo }}
+        The alert_id is {{ result.alert_id }}. The repository name is {{ result.repo }}
 
-        First check if an open issue with the alert id already exists in {{ RESULT_repo }}.
+        First check if an open issue with the alert id already exists in {{ result.repo }}.
         If it does, then do not create a new issue and your task is done.
 
-        Otherwise, create an issue in {{ RESULT_repo }} using these notes:
+        Otherwise, create an issue in {{ result.repo }} using these notes:
         ```
-        {{ RESULT_result }}
+        {{ result.result }}
         ```
         Remove any duplicate information of the notes and use it as the issue body.
         The issue body should be formatted in markdown.
@@ -113,14 +112,14 @@ taskflow:
         - Another list of entries with the factors that render the vulnerability of the alert not exploitable. Prepend each entry with a bullet point, followed by the :heavy_minus_sign: emoji.
         The issue body should be formatted in markdown.
 
-        If references to source code locations are present in the notes, link them like this: https://github.com/{{ RESULT_repo }}/blob/master/{{ RESULT_file_path }}#L{{ RESULT_line_number }}). Remove any occurences of `'` from that link.
+        If references to source code locations are present in the notes, link them like this: https://github.com/{{ result.repo }}/blob/master/{{ result.file_path }}#L{{ result.line_number }}). Remove any occurences of `'` from that link.
 
-        At the bottom of the issue body create a link to the alert like this: https://github.com/{{ RESULT_repo }}/security/code-scanning/{{ RESULT_alert_id }}, name the link `Code scanning alert #{{ RESULT_alert_id }}`. Remove any occurences of `'` from that link.
+        At the bottom of the issue body create a link to the alert like this: https://github.com/{{ result.repo }}/security/code-scanning/{{ result.alert_id }}, name the link `Code scanning alert #{{ result.alert_id }}`. Remove any occurences of `'` from that link.
         Then add following text to the issue body: 🤖 I'm a robot beep boop.
 
         The title of the issue should be:
         ```
-        Code scanning alert #{{ RESULT_alert_id }} triage report for {{ RESULT_rule }}. Remove any occurences of `'` from the rule.
+        Code scanning alert #{{ result.alert_id }} triage report for {{ result.rule }}. Remove any occurences of `'` from the rule.
         ```
         Use [barry-agent,FP] as labels for the issue.
       toolboxes:

--- a/src/seclab_taskflows/taskflows/alert_triage_examples/triage_taskflows/review_actions_injection_issues.yaml
+++ b/src/seclab_taskflows/taskflows/alert_triage_examples/triage_taskflows/review_actions_injection_issues.yaml
@@ -3,8 +3,7 @@
 
 seclab-taskflow-agent:
   filetype: taskflow
-  version: 1
-
+  version: "1.0"
 model_config: seclab_taskflows.configs.model_config
 
 taskflow:
@@ -53,7 +52,7 @@ taskflow:
         Check if reasons for dismissing other alerts in this repo applies to this alert. If it does, 
         then dismiss this alert and add a comment to the issue to explain the reason.
       user_prompt: |
-        {{ PROMPTS_seclab_taskflows.prompts.triage_taskflows.actions_common.check_dismiss_reason }}
+        {% include 'seclab_taskflows.prompts.triage_taskflows.actions_common.check_dismiss_reason' %}
 
         IMPORTANT:
         1. If the dismissal reason does not apply the issue, then you must not dismiss the alert. In particular,
@@ -74,7 +73,7 @@ taskflow:
         issue title, which is of the form. If you failed to dismiss the alert, then try to dismiss it again without providing any
         reason, but only a quote of the issue id.
         
-        {{ PROMPTS_seclab_taskflows.prompts.triage_taskflows.actions_common.dismiss_decision }}
+        {% include 'seclab_taskflows.prompts.triage_taskflows.actions_common.dismiss_decision' %}
 
       toolboxes:
         - seclab_taskflow_agent.toolboxes.github_official

--- a/src/seclab_taskflows/taskflows/alert_triage_examples/triage_taskflows/review_untrusted_checkout_issues.yaml
+++ b/src/seclab_taskflows/taskflows/alert_triage_examples/triage_taskflows/review_untrusted_checkout_issues.yaml
@@ -3,8 +3,7 @@
 
 seclab-taskflow-agent:
   filetype: taskflow
-  version: 1
-
+  version: "1.0"
 model_config: seclab_taskflows.configs.model_config
 
 taskflow:
@@ -53,9 +52,9 @@ taskflow:
         Check if reasons for dismissing other alerts in this repo applies to this alert. If it does, 
         then dismiss this alert and add a comment to the issue to explain the reason.
       user_prompt: |
-        {{ PROMPTS_seclab_taskflows.prompts.triage_taskflows.actions_common.check_dismiss_reason }}
+        {% include 'seclab_taskflows.prompts.triage_taskflows.actions_common.check_dismiss_reason' %}
         
-        {{ PROMPTS_seclab_taskflows.prompts.triage_taskflows.actions_common.dismiss_decision }}
+        {% include 'seclab_taskflows.prompts.triage_taskflows.actions_common.dismiss_decision' %}
 
       toolboxes:
         - seclab_taskflow_agent.toolboxes.github_official

--- a/src/seclab_taskflows/taskflows/alert_triage_examples/triage_taskflows/triage_actions_code_injection.yaml
+++ b/src/seclab_taskflows/taskflows/alert_triage_examples/triage_taskflows/triage_actions_code_injection.yaml
@@ -3,8 +3,7 @@
 
 seclab-taskflow-agent:
   filetype: taskflow
-  version: 1
-
+  version: "1.0"
 model_config: seclab_taskflows.configs.model_config
 
 globals: 
@@ -33,7 +32,7 @@ taskflow:
       agents:
         - seclab_taskflow_agent.personalities.assistant
       user_prompt: |
-        Fetch the alert results that has the rule `{{ GLOBALS_rule }}`.
+        Fetch the alert results that has the rule `{{ globals.rule }}`.
       toolboxes:
         - seclab_taskflows.toolboxes.report_alert_state
   - task:
@@ -48,7 +47,7 @@ taskflow:
       agents:
         - seclab_taskflow_agent.personalities.assistant
       user_prompt: |
-        Fetch the valid alert results that has the rule `{{ GLOBALS_rule }}`.
+        Fetch the valid alert results that has the rule `{{ globals.rule }}`.
       toolboxes:
         - seclab_taskflows.toolboxes.report_alert_state
   - task:
@@ -61,9 +60,9 @@ taskflow:
         - seclab_taskflows.personalities.action_expert
       model: triage
       user_prompt: |
-        The alert_id is {{ RESULT_alert_id }} and the repo is {{ RESULT_repo }}.
+        The alert_id is {{ result.alert_id }} and the repo is {{ result.repo }}.
 
-        Take a look at the code at near the alert location {{ RESULT_location }}. This usually contains some user inputs being evaluated or executed, 
+        Take a look at the code at near the alert location {{ result.location }}. This usually contains some user inputs being evaluated or executed, 
         which may lead to code injection. For example:
         ```
         run: |
@@ -77,7 +76,7 @@ taskflow:
         because it is then used in the script in the `run` field, it may lead to code injection.
 
         IMPORTANT:
-        1. Only look at the expression that is evaluated at the alert location {{ RESULT_location }}, and don't consider other 
+        1. Only look at the expression that is evaluated at the alert location {{ result.location }}, and don't consider other 
         expressions that may be evaluated in the same script or workflow. However, there may be multiple
         expressions that are evaluated at the same alert location, so you should look for all of them.
         2. Double quotations around the expression does not prevent code injection, so you should still consider it as a code injection vulnerability.
@@ -193,17 +192,17 @@ taskflow:
 
         Note any valid sanitizer or checks in the notes, including the lines of the checks or sanitizer and mention that the code is not vulnerable to code injection.
         ONLY consider the exact sanitizers stated above, and do not try to reason about other sanitizers or checks that may be present in the code.
-        Check to make sure that the sanitizers or checks happens before the code injection vulnerability at {{ RESULT_location }}.
+        Check to make sure that the sanitizers or checks happens before the code injection vulnerability at {{ result.location }}.
 
         ## Validity decision
 
         When deciding whether the code is vulnerable to code injection, DO NOT consider how the code is used in the rest of the workflow, 
-        only consider whether the code at the alert location {{ RESULT_location }} is affected by a sanitizer or a check that takes 
-        place before the code injection vulnerability at {{ RESULT_location }}.
+        only consider whether the code at the alert location {{ result.location }} is affected by a sanitizer or a check that takes 
+        place before the code injection vulnerability at {{ result.location }}.
 
-        If the sanitizer is still valid include update the alert results with these information using the alert_id {{ RESULT_alert_id }} and repo {{ RESULT_repo }} in the 
+        If the sanitizer is still valid include update the alert results with these information using the alert_id {{ result.alert_id }} and repo {{ result.repo }} in the 
         `update_alert_result` tool with your notes as the `result`. Remember to include the line numbers of the checks or sanitizers in the notes.
-        and then set the `valid` field of the alert result to `false` using alert_id {{ RESULT_alert_id }} and repo {{ RESULT_repo }}.
+        and then set the `valid` field of the alert result to `false` using alert_id {{ result.alert_id }} and repo {{ result.repo }}.
 
         IMPORTANT:
         You must only based your decision on the present of sanitizer and check and not any other factors. And do not include 
@@ -219,7 +218,7 @@ taskflow:
       agents:
         - seclab_taskflow_agent.personalities.assistant
       user_prompt: |
-        Fetch the valid alert results from that has the rule `{{ GLOBALS_rule }}`.
+        Fetch the valid alert results from that has the rule `{{ globals.rule }}`.
       toolboxes:
         - seclab_taskflows.toolboxes.report_alert_state
   - task:
@@ -250,7 +249,7 @@ taskflow:
       agents:
         - seclab_taskflow_agent.personalities.assistant
       user_prompt: |
-        Fetch the all the alert results from that has the rule `{{ GLOBALS_rule }}`.
+        Fetch the all the alert results from that has the rule `{{ globals.rule }}`.
       toolboxes:
         - seclab_taskflows.toolboxes.report_alert_state
   - task:
@@ -270,7 +269,7 @@ taskflow:
       agents:
         - seclab_taskflow_agent.personalities.assistant
       user_prompt: |
-        Fetch the valid the alert results from that has the rule `{{ GLOBALS_rule }}`.
+        Fetch the valid the alert results from that has the rule `{{ globals.rule }}`.
       toolboxes:
         - seclab_taskflows.toolboxes.report_alert_state
   - task:
@@ -281,8 +280,8 @@ taskflow:
       inputs:
         title: Code injection in Github Actions <action_name>
         vul_specifics: |
-          First, the report should state that the GitHub action at {{ RESULT_location }} executing user input. 
-          Add a code snippet from the file at {{ RESULT_location }} that contains the code injection vulnerability and 
+          First, the report should state that the GitHub action at {{ result.location }} executing user input. 
+          Add a code snippet from the file at {{ result.location }} that contains the code injection vulnerability and 
           explain which user input is being evaluated or executed, which may lead to code injection.
   - task:
       must_complete: true

--- a/src/seclab_taskflows/taskflows/alert_triage_examples/triage_taskflows/triage_js_ts_client_side_xss.yaml
+++ b/src/seclab_taskflows/taskflows/alert_triage_examples/triage_taskflows/triage_js_ts_client_side_xss.yaml
@@ -3,8 +3,7 @@
 
 seclab-taskflow-agent:
   filetype: taskflow
-  version: 1
-
+  version: "1.0"
 model_config: seclab_taskflows.configs.model_config
 
 globals:
@@ -30,7 +29,7 @@ taskflow:
       agents:
         - seclab_taskflow_agent.personalities.assistant
       user_prompt: |
-        Fetch the alert results that has the rule `{{ GLOBALS_rule }}`.
+        Fetch the alert results that has the rule `{{ globals.rule }}`.
       toolboxes:
         - seclab_taskflows.toolboxes.report_alert_state
   - task:
@@ -45,7 +44,7 @@ taskflow:
       description: |
         Perform local analysis to look for sanitizer that may result in a FP.
       user_prompt: |
-        Inspect the alert location at {{ RESULT_location }} in the repo {{ RESULT_repo }} to determine if it is in an exploitable client-side cross-site scripting (XSS) vulnerability.
+        Inspect the alert location at {{ result.location }} in the repo {{ result.repo }} to determine if it is in an exploitable client-side cross-site scripting (XSS) vulnerability.
         Client-side means that the code is executed in the user's browser, not on the server.
 
         In this task, restrict your analysis to the function that contains the alert location only. Do not trace the calls of the function. Just
@@ -80,8 +79,8 @@ taskflow:
         Take notes while assessing the alert.
         If prompt token count exceeds the given limit note this in the result and mark the task as complete.
         Update the results field of the alert result with your notes using `update_alert_result` with 
-        {{ RESULT_alert_id }} as alert_id and {{ RESULT_repo }} as repo.
-        When you are done, set the `valid` field of the alert result to `true` using alert_id {{ RESULT_alert_id }} and repo {{ RESULT_repo }}
+        {{ result.alert_id }} as alert_id and {{ result.repo }} as repo.
+        When you are done, set the `valid` field of the alert result to `true` using alert_id {{ result.alert_id }} and repo {{ result.repo }}
         if the alert is a potential vulnerability, otherwise set it to `false`. 
       toolboxes:
         - seclab_taskflows.toolboxes.gh_file_viewer
@@ -93,7 +92,7 @@ taskflow:
       agents:
         - seclab_taskflow_agent.personalities.assistant
       user_prompt: |
-        Fetch the valid alert results that has the rule `{{ GLOBALS_rule }}`.
+        Fetch the valid alert results that has the rule `{{ globals.rule }}`.
       toolboxes:
         - seclab_taskflows.toolboxes.report_alert_state
   - task:
@@ -123,7 +122,7 @@ taskflow:
       agents:
         - seclab_taskflow_agent.personalities.assistant
       user_prompt: |
-        Fetch the valid alert results that has the rule `{{ GLOBALS_rule }}`.
+        Fetch the valid alert results that has the rule `{{ globals.rule }}`.
       toolboxes:
         - seclab_taskflows.toolboxes.report_alert_state
   - task:
@@ -141,7 +140,7 @@ taskflow:
       agents:
         - seclab_taskflow_agent.personalities.assistant
       user_prompt: |
-        Fetch the valid alert results that has the rule `{{ GLOBALS_rule }}`.
+        Fetch the valid alert results that has the rule `{{ globals.rule }}`.
       toolboxes:
         - seclab_taskflows.toolboxes.report_alert_state
   - task:

--- a/src/seclab_taskflows/taskflows/alert_triage_examples/triage_taskflows/triage_js_ts_path_injection.yaml
+++ b/src/seclab_taskflows/taskflows/alert_triage_examples/triage_taskflows/triage_js_ts_path_injection.yaml
@@ -3,8 +3,7 @@
 
 seclab-taskflow-agent:
   filetype: taskflow
-  version: 1
-
+  version: "1.0"
 model_config: seclab_taskflows.configs.model_config
 
 taskflow:
@@ -39,7 +38,7 @@ taskflow:
         - seclab_taskflows.personalities.web_application_security_expert
       async: true
       user_prompt: |
-        Inspect the alert location at {{ RESULT_location }} in the repo {{ RESULT_repo }} to determine if it is in an exploitable path traversal vulnerability.
+        Inspect the alert location at {{ result.location }} in the repo {{ result.repo }} to determine if it is in an exploitable path traversal vulnerability.
         Exploitable means that a remote attacker would be able to control a path e.g. by sending a crafted request to the application containing a path traversal payload like `../`.
         It also means that the path traversal vulnerability is not mitigated by any other code in the repository, such as sanitization or validation of the path.
         And that the sink is a method that is used to read, write or delete files, such as `fs.readFile`, `fs.writeFile`, `fs.createWriteStream`, etc.
@@ -51,8 +50,8 @@ taskflow:
         Always note where the URL path is registered in the web framework and the HTTP method required to call it. Write the lines that register the URL path in the notes.
         Take notes while assessing the alert.
         Update the results field of the alert result with your notes using `update_alert_result` with 
-        {{ RESULT_alert_id }} as alert_id and {{ RESULT_repo }} as repo.
-        When you are done, set the `valid` field of the alert result to `true` using alert_id {{ RESULT_alert_id }} and repo {{ RESULT_repo }}
+        {{ result.alert_id }} as alert_id and {{ result.repo }} as repo.
+        When you are done, set the `valid` field of the alert result to `true` using alert_id {{ result.alert_id }} and repo {{ result.repo }}
         if the alert is a potential vulnerability, otherwise set it to `false`. 
       toolboxes:
         - seclab_taskflows.toolboxes.gh_file_viewer

--- a/src/seclab_taskflows/taskflows/alert_triage_examples/triage_taskflows/triage_untrusted_checkout_critical.yaml
+++ b/src/seclab_taskflows/taskflows/alert_triage_examples/triage_taskflows/triage_untrusted_checkout_critical.yaml
@@ -3,8 +3,7 @@
 
 seclab-taskflow-agent:
   filetype: taskflow
-  version: 1
-
+  version: "1.0"
 model_config: seclab_taskflows.configs.model_config
 
 globals: 
@@ -31,7 +30,7 @@ taskflow:
       agents:
         - seclab_taskflow_agent.personalities.assistant
       user_prompt: |
-        Fetch the alert results that has the rule `{{ GLOBALS_rule }}`.
+        Fetch the alert results that has the rule `{{ globals.rule }}`.
       toolboxes:
         - seclab_taskflows.toolboxes.report_alert_state
   - task:
@@ -46,7 +45,7 @@ taskflow:
       agents:
         - seclab_taskflow_agent.personalities.assistant
       user_prompt: |
-        Fetch the valid alert results that has the rule `{{ GLOBALS_rule }}`.
+        Fetch the valid alert results that has the rule `{{ globals.rule }}`.
       toolboxes:
         - seclab_taskflows.toolboxes.report_alert_state
   - task:
@@ -74,9 +73,9 @@ taskflow:
         the notes.
         If you cannot find any such invocation, then mention that in your notes as well.
         Update the results field of the alert result with your notes using `update_alert_result` with 
-        {{ RESULT_alert_id }} as alert_id and {{ RESULT_repo }} as repo.
+        {{ result.alert_id }} as alert_id and {{ result.repo }} as repo.
 
-        When you are done, set the `valid` field of the alert result to `true` using alert_id {{ RESULT_alert_id }} and repo {{ RESULT_repo }}
+        When you are done, set the `valid` field of the alert result to `true` using alert_id {{ result.alert_id }} and repo {{ result.repo }}
         if the alert is a potential vulnerability, otherwise set it to `false`. 
         IMPORTANT: You must also do the following checks.
         1.If the ONLY alert trigger is `workflow_dispatche`, then you should set the `valid` field to `false` and update the alert result with the reason that the trigger is `workflow_dispatch`.
@@ -100,7 +99,7 @@ taskflow:
       agents:
         - seclab_taskflow_agent.personalities.assistant
       user_prompt: |
-        Fetch the valid alert results from that has the rule `{{ GLOBALS_rule }}`.
+        Fetch the valid alert results from that has the rule `{{ globals.rule }}`.
       toolboxes:
         - seclab_taskflows.toolboxes.report_alert_state
   - task:
@@ -131,7 +130,7 @@ taskflow:
       agents:
         - seclab_taskflow_agent.personalities.assistant
       user_prompt: |
-        Fetch the all the alert results from that has the rule `{{ GLOBALS_rule }}`.
+        Fetch the all the alert results from that has the rule `{{ globals.rule }}`.
       toolboxes:
         - seclab_taskflows.toolboxes.report_alert_state
   - task:
@@ -158,7 +157,7 @@ taskflow:
       agents:
         - seclab_taskflow_agent.personalities.assistant
       user_prompt: |
-        Fetch the valid the alert results from that has the rule `{{ GLOBALS_rule }}`.
+        Fetch the valid the alert results from that has the rule `{{ globals.rule }}`.
       toolboxes:
         - seclab_taskflows.toolboxes.report_alert_state
   - task:
@@ -169,8 +168,8 @@ taskflow:
       inputs:
         title: Checking out of untrusted code in Github Actions <action_name> may lead to code execution in privileged context/secret leak
         vul_specifics: |
-          First, the report should state that the GitHub action at {{ RESULT_location }} is checking out untrusted code. You should then include 
-          a code snippet from the file at the alert location {{ RESULT_location }}, that contains the few lines around the location where 
+          First, the report should state that the GitHub action at {{ result.location }} is checking out untrusted code. You should then include 
+          a code snippet from the file at the alert location {{ result.location }}, that contains the few lines around the location where 
           the `checkout` action is used.
 
           Next, from the analysis of the alert, identify any invocation of untrusted code after the location of the alert, where untrusted code is checked out.
@@ -187,7 +186,7 @@ taskflow:
             these cases are also considered untrusted code.
           Only include the line number and code snippet from the action file that contains the invocation of untrusted code
           in the report. Ignore the invocations that are not considered untrusted code. 
-          In the report, include code snippet where the that untrusted code is invoked from the file at {{ RESULT_location }}, 
+          In the report, include code snippet where the that untrusted code is invoked from the file at {{ result.location }}, 
           mention the line number where the untrusted code is invoked. Explain that because the action has checked out to 
           an attacker-controlled branch, the code that is invoked now lives on that branch and is under the control of the attacker,
           this invocation is therefore now executing attacker-controlled code in the context of the GitHub action.

--- a/src/seclab_taskflows/taskflows/audit/acl_check.yaml
+++ b/src/seclab_taskflows/taskflows/audit/acl_check.yaml
@@ -3,8 +3,7 @@
 
 seclab-taskflow-agent:
   filetype: taskflow
-  version: 1
-
+  version: "1.0"
 model_config: seclab_taskflows.configs.model_config
 
 globals:
@@ -18,7 +17,7 @@ taskflow:
         - seclab_taskflows.personalities.web_application_security_expert
       model: code_analysis
       user_prompt: |
-        Fetch the list of issues for component {{ GLOBALS_id }} in repo {{ GLOBALS_repo }}. Check if there is any issue 
+        Fetch the list of issues for component {{ globals.id }} in repo {{ globals.repo }}. Check if there is any issue 
         that involves access control or authentication. If there isn't any, then your task is finished.
 
         If there are any authentication or access control that are crucial in determining whether issue is vulnerable or not,

--- a/src/seclab_taskflows/taskflows/audit/audit_issue.yaml
+++ b/src/seclab_taskflows/taskflows/audit/audit_issue.yaml
@@ -3,8 +3,7 @@
 
 seclab-taskflow-agent:
   filetype: taskflow
-  version: 1
-
+  version: "1.0"
 model_config: seclab_taskflows.configs.model_config
 
 globals:
@@ -18,7 +17,7 @@ taskflow:
         - seclab_taskflows.personalities.web_application_security_expert
       model: code_analysis
       user_prompt: |
-        Fetch the issues in component with id {{ GLOBALS_id }} in the repo {{ GLOBALS_repo }}. Audit the second issue that was suggested.
+        Fetch the issues in component with id {{ globals.id }} in the repo {{ globals.repo }}. Audit the second issue that was suggested.
 
         The issues suggested are have not been probably verified and are only suggested because they are common issues in these types of 
         application. You task is to audit the source code to check if this type of issues is present.

--- a/src/seclab_taskflows/taskflows/audit/audit_issue_local.yaml
+++ b/src/seclab_taskflows/taskflows/audit/audit_issue_local.yaml
@@ -3,8 +3,7 @@
 
 seclab-taskflow-agent:
   filetype: taskflow
-  version: 1
-
+  version: "1.0"
 model_config: seclab_taskflows.configs.model_config
 
 globals:
@@ -19,9 +18,9 @@ taskflow:
         - seclab_taskflows.personalities.web_application_security_expert
       model: code_analysis
       user_prompt: |
-        Fetch the issues in component with id {{ GLOBALS_id }} in the repo {{ GLOBALS_repo }}. Audit the first issue.
+        Fetch the issues in component with id {{ globals.id }} in the repo {{ globals.repo }}. Audit the first issue.
 
-        {{ PROMPTS_seclab_taskflows.prompts.audit.audit_issue }}
+        {% include 'seclab_taskflows.prompts.audit.audit_issue' %}
       toolboxes:
         - seclab_taskflows.toolboxes.repo_context
         - seclab_taskflows.toolboxes.local_file_viewer

--- a/src/seclab_taskflows/taskflows/audit/audit_issue_local_iter.yaml
+++ b/src/seclab_taskflows/taskflows/audit/audit_issue_local_iter.yaml
@@ -3,8 +3,7 @@
 
 seclab-taskflow-agent:
   filetype: taskflow
-  version: 1
-
+  version: "1.0"
 model_config: seclab_taskflows.configs.model_config
 
 globals:
@@ -18,7 +17,7 @@ taskflow:
         - seclab_taskflow_agent.personalities.assistant
       model: general_tasks
       user_prompt: |
-        Fetch the component issues in {{ GLOBALS_repo }}.
+        Fetch the component issues in {{ globals.repo }}.
       toolboxes:
         - seclab_taskflows.toolboxes.repo_context
   - task:
@@ -30,19 +29,19 @@ taskflow:
         - seclab_taskflows.personalities.web_application_security_expert
       model: code_analysis
       user_prompt: |
-        The issue is in repo {{ RESULT_repo }} with id {{ RESULT_issue_id }}. The component is under the directory 
-        {{ RESULT_location }} with component_id {{ RESULT_component_id }}. The notes of the component is:
+        The issue is in repo {{ result.repo }} with id {{ result.issue_id }}. The component is under the directory 
+        {{ result.location }} with component_id {{ result.component_id }}. The notes of the component is:
 
-        {{ RESULT_component_notes }}
+        {{ result.component_notes }}
         
         You should use this to understand the intended purpose of the component and take it into account when 
         you audit the issue.
 
-        The type of the issue is {{ RESULT_issue_type }} and here is the notes of the issue:
+        The type of the issue is {{ result.issue_type }} and here is the notes of the issue:
 
-        {{ RESULT_issue_notes }}
+        {{ result.issue_notes }}
 
-        {{ PROMPTS_seclab_taskflows.prompts.audit.audit_issue }}
+        {% include 'seclab_taskflows.prompts.audit.audit_issue' %}
       toolboxes:
         - seclab_taskflows.toolboxes.repo_context
         - seclab_taskflows.toolboxes.local_file_viewer

--- a/src/seclab_taskflows/taskflows/audit/audit_sanitizers.yaml
+++ b/src/seclab_taskflows/taskflows/audit/audit_sanitizers.yaml
@@ -3,8 +3,7 @@
 
 seclab-taskflow-agent:
   filetype: taskflow
-  version: 1
-
+  version: "1.0"
 model_config: seclab_taskflows.configs.model_config
 
 globals:
@@ -19,10 +18,10 @@ taskflow:
         - seclab_taskflows.personalities.web_application_security_expert
       model: code_analysis
       user_prompt: |
-        Fetch the entry points of the repo {{ GLOBALS_repo }},
-        the user actions of the repo {{ GLOBALS_repo }} and the 
-        components of the repo {{ GLOBALS_repo }}.
-        Based on the entry points, components, user actions and README.md and, if available, SECURITY.md in the {{ GLOBALS_repo }},
+        Fetch the entry points of the repo {{ globals.repo }},
+        the user actions of the repo {{ globals.repo }} and the 
+        components of the repo {{ globals.repo }}.
+        Based on the entry points, components, user actions and README.md and, if available, SECURITY.md in the {{ globals.repo }},
         can you tell me what type of application this repo is and what kind of security boundary it has.
         For each entry point state whether they could be used for security relevant functionality. (E.g. checking that an input is well-formed) 
         Add a note regarding the most likely security problems in this entry point. E.g. if a function is used to verify some data format and
@@ -49,6 +48,6 @@ taskflow:
         - seclab_taskflows.personalities.web_application_security_expert
       model: code_analysis
       user_prompt: |
-        Fetch the issues in component with id {{ GLOBALS_id }} in the repo {{ GLOBALS_repo }}. List all issues one by one.
+        Fetch the issues in component with id {{ globals.id }} in the repo {{ globals.repo }}. List all issues one by one.
       toolboxes:
         - seclab_taskflows.toolboxes.repo_context

--- a/src/seclab_taskflows/taskflows/audit/classify_application.yaml
+++ b/src/seclab_taskflows/taskflows/audit/classify_application.yaml
@@ -3,8 +3,7 @@
 
 seclab-taskflow-agent:
   filetype: taskflow
-  version: 1
-
+  version: "1.0"
 model_config: seclab_taskflows.configs.model_config
 
 globals:
@@ -18,10 +17,10 @@ taskflow:
         - seclab_taskflows.personalities.web_application_security_expert
       model: code_analysis
       user_prompt: |
-        Fetch the entry points of the repo {{ GLOBALS_repo }},
-        the user actions of the repo {{ GLOBALS_repo }} and the 
-        the components of the repo {{ GLOBALS_repo }}.
-        Based on the entry points, components, user actions and README.md and if available, SECURITY.md in the {{ GLOBALS_repo }},
+        Fetch the entry points of the repo {{ globals.repo }},
+        the user actions of the repo {{ globals.repo }} and the 
+        the components of the repo {{ globals.repo }}.
+        Based on the entry points, components, user actions and README.md and if available, SECURITY.md in the {{ globals.repo }},
         can you tell me what type of application this repo is and what kind of security boundary it has.
         Based on this, identify the components that are most likely to have security problems. For each component, 
         state the precise component id, and the location. (You can group multiple components that serves a single functionalities together)
@@ -49,7 +48,7 @@ taskflow:
         - seclab_taskflows.personalities.web_application_security_expert
       model: code_analysis
       user_prompt: |
-        Fetch the issues in component with id {{ GLOBALS_id }} in the repo {{ GLOBALS_repo }}. Give a summary of each type of issue in this
+        Fetch the issues in component with id {{ globals.id }} in the repo {{ globals.repo }}. Give a summary of each type of issue in this
         component.
       toolboxes:
         - seclab_taskflows.toolboxes.repo_context

--- a/src/seclab_taskflows/taskflows/audit/classify_application_local.yaml
+++ b/src/seclab_taskflows/taskflows/audit/classify_application_local.yaml
@@ -3,8 +3,7 @@
 
 seclab-taskflow-agent:
   filetype: taskflow
-  version: 1
-
+  version: "1.0"
 model_config: seclab_taskflows.configs.model_config
 
 globals:
@@ -18,7 +17,7 @@ taskflow:
         - seclab_taskflow_agent.personalities.assistant
       model: general_tasks
       user_prompt: |
-        Fetch the components of the repo {{ GLOBALS_repo }}
+        Fetch the components of the repo {{ globals.repo }}
       toolboxes:
         - seclab_taskflows.toolboxes.repo_context
   - task:
@@ -29,13 +28,13 @@ taskflow:
         - seclab_taskflows.personalities.web_application_security_expert
       model: code_analysis
       user_prompt: |
-        The component is in the repo {{ RESULT_repo }} and it has component id {{ RESULT_app_id }} and location {{ RESULT_location }}.
+        The component is in the repo {{ result.repo }} and it has component id {{ result.app_id }} and location {{ result.location }}.
         The notes of the component is as follows.
 
-        {{ RESULT_notes }}
+        {{ result.notes }}
 
         Fetch the entry points and web entry points the component, then the user actions of this component.
-        Based on the entry points, web entry points, components, user actions and README.md and if available, SECURITY.md in the {{ GLOBALS_repo }},
+        Based on the entry points, web entry points, components, user actions and README.md and if available, SECURITY.md in the {{ globals.repo }},
         can you tell me what type of application this repo is and what kind of security boundary it has.
         Based on this, determine whether the components that is likely to have security problems. 
         

--- a/src/seclab_taskflows/taskflows/audit/fetch_audit_issue.yaml
+++ b/src/seclab_taskflows/taskflows/audit/fetch_audit_issue.yaml
@@ -3,8 +3,7 @@
 
 seclab-taskflow-agent:
   filetype: taskflow
-  version: 1
-
+  version: "1.0"
 model_config: seclab_taskflows.configs.model_config
 
 globals:
@@ -17,7 +16,7 @@ taskflow:
         - seclab_taskflows.personalities.web_application_security_expert
       model: code_analysis
       user_prompt: |
-        Fetch the audit results in {{ GLOBALS_repo }}. Give a summary of the notes, include what has been looked at,
+        Fetch the audit results in {{ globals.repo }}. Give a summary of the notes, include what has been looked at,
         reason of the decision,
         list each area and issue and include the precise file and line
         in the report. If it is a vulnerability, also state the attack scenarios

--- a/src/seclab_taskflows/taskflows/audit/fetch_source_code.yaml
+++ b/src/seclab_taskflows/taskflows/audit/fetch_source_code.yaml
@@ -3,8 +3,7 @@
 
 seclab-taskflow-agent:
   filetype: taskflow
-  version: 1
-
+  version: "1.0"
 model_config: seclab_taskflows.configs.model_config
 
 globals:
@@ -18,6 +17,6 @@ taskflow:
         - seclab_taskflow_agent.personalities.assistant
       model: general_tasks
       user_prompt: |
-        Fetch the source code of the repo {{ GLOBALS_repo }}.
+        Fetch the source code of the repo {{ globals.repo }}.
       toolboxes:
         - seclab_taskflows.toolboxes.local_gh_resources

--- a/src/seclab_taskflows/taskflows/audit/gather_web_entry_point_info.yaml
+++ b/src/seclab_taskflows/taskflows/audit/gather_web_entry_point_info.yaml
@@ -3,8 +3,7 @@
 
 seclab-taskflow-agent:
   filetype: taskflow
-  version: 1
-
+  version: "1.0"
 model_config: seclab_taskflows.configs.model_config
 
 globals:
@@ -19,7 +18,7 @@ taskflow:
       agents:
         - seclab_taskflows.personalities.web_application_security_expert
       user_prompt: |
-        For the repo {{ GLOBALS_repo }} iterate over all entry points and and check if they are
+        For the repo {{ globals.repo }} iterate over all entry points and and check if they are
         reachable as a server endpoint.
         For this check the noted `file` and it's line using the file viewer.
         Then note it's path, HTTP method and note any middlewares used. Also note which roles are

--- a/src/seclab_taskflows/taskflows/audit/gather_web_entry_point_info_local.yaml
+++ b/src/seclab_taskflows/taskflows/audit/gather_web_entry_point_info_local.yaml
@@ -3,8 +3,7 @@
 
 seclab-taskflow-agent:
   filetype: taskflow
-  version: 1
-
+  version: "1.0"
 model_config: seclab_taskflows.configs.model_config
 
 globals:
@@ -19,7 +18,7 @@ taskflow:
       agents:
         - seclab_taskflow_agent.personalities.assistant
       user_prompt: |
-        Fetch the components of the repo {{ GLOBALS_repo }}.
+        Fetch the components of the repo {{ globals.repo }}.
       toolboxes:
         - seclab_taskflows.toolboxes.repo_context
   - task:
@@ -31,7 +30,7 @@ taskflow:
       agents:
         - seclab_taskflows.personalities.web_application_security_expert
       user_prompt: |
-        The component has component_id {{ RESULT_app_id }} and location {{ RESULT_location }} in the repo {{ RESULT_repo }}.
+        The component has component_id {{ result.app_id }} and location {{ result.location }} in the repo {{ result.repo }}.
         Fetch the entry points of the component and for each entry point, check if this entry point is a server endpoint.
         If it is reachble as a server endpoint, then you need to find the following by looking through the relevant files:
         - The routing path that reaches this entry point 

--- a/src/seclab_taskflows/taskflows/audit/ghsa_variant_analysis_demo.yaml
+++ b/src/seclab_taskflows/taskflows/audit/ghsa_variant_analysis_demo.yaml
@@ -8,8 +8,7 @@
 
 seclab-taskflow-agent:
   filetype: taskflow
-  version: 1
-
+  version: "1.0"
 globals:
   repo:
   ghsa:
@@ -33,7 +32,7 @@ taskflow:
         - seclab_taskflows.toolboxes.gh_file_viewer
         - seclab_taskflow_agent.toolboxes.memcache
       user_prompt: |
-        Fetch the details of the GHSA {{ GLOBALS_ghsa }} of the repo {{ GLOBALS_repo }}.
+        Fetch the details of the GHSA {{ globals.ghsa }} of the repo {{ globals.repo }}.
 
         Analyze the description to understand what type of bug caused
         the vulnerability. DO NOT perform a code audit at this stage, just 
@@ -73,7 +72,7 @@ taskflow:
         fetching the entire file.
 
         Fetch the source file that was identified as the cause of the
-        GHSA in repo {{ GLOBALS_repo }}. 
+        GHSA in repo {{ globals.repo }}. 
 
         Do a security audit of the code in the source file, focusing
         particularly on the type of bug that was identified as the

--- a/src/seclab_taskflows/taskflows/audit/identify_applications.yaml
+++ b/src/seclab_taskflows/taskflows/audit/identify_applications.yaml
@@ -3,8 +3,7 @@
 
 seclab-taskflow-agent:
   filetype: taskflow
-  version: 1
-
+  version: "1.0"
 model_config: seclab_taskflows.configs.model_config
 
 globals:
@@ -18,7 +17,7 @@ taskflow:
       agents:
         - seclab_taskflow_agent.personalities.assistant
       user_prompt: |
-        Clear the memory cache and clear the repo context results for repo {{ GLOBALS_repo }}
+        Clear the memory cache and clear the repo context results for repo {{ globals.repo }}
       toolboxes:
         - seclab_taskflow_agent.toolboxes.memcache
         - seclab_taskflows.toolboxes.repo_context
@@ -30,7 +29,7 @@ taskflow:
       agents:
         - seclab_taskflows.personalities.web_application_security_expert
       user_prompt: |
-        Inspect {{ GLOBALS_repo }} and determine its function. Determine whether the repo is a framework library,
+        Inspect {{ globals.repo }} and determine its function. Determine whether the repo is a framework library,
         or a web application etc. For repo that may contain multiple applications, determine the purpose of each 
         application and the directories of each application. Repo can also be a library but contains actual applications, for 
         example, a web server and admin UI etc. that are not for testing or examples.
@@ -56,7 +55,7 @@ taskflow:
       agents:
         - seclab_taskflow_agent.personalities.assistant
       user_prompt: |
-          Fetch the components from the repo {{ GLOBALS_repo }}.
+          Fetch the components from the repo {{ globals.repo }}.
       toolboxes:
         - seclab_taskflows.toolboxes.repo_context
   - task:
@@ -70,16 +69,16 @@ taskflow:
       agents:
         - seclab_taskflows.personalities.web_application_security_expert
       user_prompt: |
-        The component is in {{ RESULT_repo }} in the directory {{ RESULT_location }}. These are the 
+        The component is in {{ result.repo }} in the directory {{ result.location }}. These are the 
         notes for this component:
 
-        {{ RESULT_notes }}
+        {{ result.notes }}
 
         Analyze the entry points of this application. First check whether this component is a library or 
         an application. From previous analysis stated that:
 
-        is_application ? {{ RESULT_is_app }}
-        is_library ? {{ RESULT_is_library }}
+        is_application ? {{ result.is_app }}
+        is_library ? {{ result.is_library }}
         
         ## Application
 
@@ -139,7 +138,7 @@ taskflow:
       agents:
         - seclab_taskflow_agent.personalities.assistant
       user_prompt: |
-          Fetch the components from the repo {{ GLOBALS_repo }}.
+          Fetch the components from the repo {{ globals.repo }}.
       toolboxes:
         - seclab_taskflows.toolboxes.repo_context
   - task:
@@ -153,10 +152,10 @@ taskflow:
       agents:
         - seclab_taskflows.personalities.web_application_security_expert
       user_prompt: |
-        The component is in {{ RESULT_repo }} in the directory {{ RESULT_location }}. These are the 
+        The component is in {{ result.repo }} in the directory {{ result.location }}. These are the 
         notes for this component:
 
-        {{ RESULT_notes }}
+        {{ result.notes }}
 
         Analyze the actions that an untrusted user is allowed to perform. The purpose of this task is not 
         about the security of the source code, but rather get an understanding of the purpose of the component and 
@@ -175,8 +174,8 @@ taskflow:
         First check whether this component is a library or 
         an application. From previous analysis stated that:
 
-        is_application ? {{ RESULT_is_app }}
-        is_library ? {{ RESULT_is_library }}
+        is_application ? {{ result.is_app }}
+        is_library ? {{ result.is_library }}
 
         ## Application
         
@@ -232,7 +231,7 @@ taskflow:
         - seclab_taskflows.personalities.web_application_security_expert
       model: code_analysis
       user_prompt: |
-        Fetch the entry points of the repo {{ GLOBALS_repo }} and give a summary of the notes. 
-        Fetch the user actions of the repo {{ GLOBALS_repo }} and give a summary of the notes.
+        Fetch the entry points of the repo {{ globals.repo }} and give a summary of the notes. 
+        Fetch the user actions of the repo {{ globals.repo }} and give a summary of the notes.
       toolboxes:
         - seclab_taskflows.toolboxes.repo_context

--- a/src/seclab_taskflows/taskflows/audit/identify_applications_local.yaml
+++ b/src/seclab_taskflows/taskflows/audit/identify_applications_local.yaml
@@ -3,8 +3,7 @@
 
 seclab-taskflow-agent:
   filetype: taskflow
-  version: 1
-
+  version: "1.0"
 model_config: seclab_taskflows.configs.model_config
 
 globals:
@@ -18,8 +17,8 @@ taskflow:
       agents:
         - seclab_taskflow_agent.personalities.assistant
       user_prompt: |
-        Clear the memory cache and clear the repo context results for repo {{ GLOBALS_repo }}. 
-        Fetch the source code of the repo {{ GLOBALS_repo }}.
+        Clear the memory cache and clear the repo context results for repo {{ globals.repo }}. 
+        Fetch the source code of the repo {{ globals.repo }}.
       toolboxes:
         - seclab_taskflow_agent.toolboxes.memcache
         - seclab_taskflows.toolboxes.repo_context
@@ -33,7 +32,7 @@ taskflow:
       agents:
         - seclab_taskflows.personalities.web_application_security_expert
       user_prompt: |
-        Inspect {{ GLOBALS_repo }} and determine its function. Determine whether the repo is a framework library,
+        Inspect {{ globals.repo }} and determine its function. Determine whether the repo is a framework library,
         or a web application etc. For repo that may contain multiple applications, determine the purpose of each 
         application and the directories of each application. Repo can also be a library but contains actual applications, for 
         example, a web server and admin UI etc. that are not for testing or examples.
@@ -67,7 +66,7 @@ taskflow:
       agents:
         - seclab_taskflow_agent.personalities.assistant
       user_prompt: |
-          Fetch the components from the repo {{ GLOBALS_repo }}.
+          Fetch the components from the repo {{ globals.repo }}.
       toolboxes:
         - seclab_taskflows.toolboxes.repo_context
   - task:
@@ -81,16 +80,16 @@ taskflow:
       agents:
         - seclab_taskflows.personalities.web_application_security_expert
       user_prompt: |
-        The component is in {{ RESULT_repo }} in the directory {{ RESULT_location }}. These are the 
+        The component is in {{ result.repo }} in the directory {{ result.location }}. These are the 
         notes for this component:
 
-        {{ RESULT_notes }}
+        {{ result.notes }}
 
         Analyze the entry points of this application. First check whether this component is a library or 
         an application. From previous analysis stated that:
 
-        is_application ? {{ RESULT_is_app }}
-        is_library ? {{ RESULT_is_library }}
+        is_application ? {{ result.is_app }}
+        is_library ? {{ result.is_library }}
         
         ## Application
 
@@ -150,7 +149,7 @@ taskflow:
       agents:
         - seclab_taskflow_agent.personalities.assistant
       user_prompt: |
-          Fetch the components from the repo {{ GLOBALS_repo }}.
+          Fetch the components from the repo {{ globals.repo }}.
       toolboxes:
         - seclab_taskflows.toolboxes.repo_context
   - task:
@@ -164,10 +163,10 @@ taskflow:
       agents:
         - seclab_taskflows.personalities.web_application_security_expert
       user_prompt: |
-        The component is in {{ RESULT_repo }} in the directory {{ RESULT_location }}. These are the 
+        The component is in {{ result.repo }} in the directory {{ result.location }}. These are the 
         notes for this component:
 
-        {{ RESULT_notes }}
+        {{ result.notes }}
 
         Analyze the actions that an untrusted user is allowed to perform. The purpose of this task is not 
         about the security of the source code, but rather get an understanding of the purpose of the component and 
@@ -186,8 +185,8 @@ taskflow:
         First check whether this component is a library or 
         an application. From previous analysis stated that:
 
-        is_application ? {{ RESULT_is_app }}
-        is_library ? {{ RESULT_is_library }}
+        is_application ? {{ result.is_app }}
+        is_library ? {{ result.is_library }}
 
         ## Application
         
@@ -243,7 +242,7 @@ taskflow:
         - seclab_taskflows.personalities.web_application_security_expert
       model: code_analysis
       user_prompt: |
-        Fetch the entry points of the repo {{ GLOBALS_repo }} and give a summary of the notes. 
-        Fetch the user actions of the repo {{ GLOBALS_repo }} and give a summary of the notes.
+        Fetch the entry points of the repo {{ globals.repo }} and give a summary of the notes. 
+        Fetch the user actions of the repo {{ globals.repo }} and give a summary of the notes.
       toolboxes:
         - seclab_taskflows.toolboxes.repo_context

--- a/src/seclab_taskflows/taskflows/audit/inspect_issue.yaml
+++ b/src/seclab_taskflows/taskflows/audit/inspect_issue.yaml
@@ -3,8 +3,7 @@
 
 seclab-taskflow-agent:
   filetype: taskflow
-  version: 1
-
+  version: "1.0"
 model_config: seclab_taskflows.configs.model_config
 
 globals:
@@ -17,8 +16,8 @@ taskflow:
         - seclab_taskflows.personalities.web_application_security_expert
       model: code_analysis
       user_prompt: |
-        Fetch the components in {{ GLOBALS_repo }} and then identify the one where {{ GLOBALS_location }}
-        belong. Give me the id of this component, then. Fetch the issues in this component in the repo {{ GLOBALS_repo }}. Give a summary of each type of issue in this
+        Fetch the components in {{ globals.repo }} and then identify the one where {{ globals.location }}
+        belong. Give me the id of this component, then. Fetch the issues in this component in the repo {{ globals.repo }}. Give a summary of each type of issue in this
         component.
       toolboxes:
         - seclab_taskflows.toolboxes.repo_context

--- a/src/seclab_taskflows/taskflows/audit/js_ts_endpoint_access_checks.yaml
+++ b/src/seclab_taskflows/taskflows/audit/js_ts_endpoint_access_checks.yaml
@@ -3,8 +3,7 @@
 
 seclab-taskflow-agent:
   filetype: taskflow
-  version: 1
-
+  version: "1.0"
 # Taskflow to analyze the access control checks of endpoints in a JavaScript or TypeScript web project.
 # It uses a CodeQL database for the analysis. (specified by the repo_nwo input)
 taskflow:
@@ -25,7 +24,7 @@ taskflow:
       inputs:
         repo_nwo: 
       user_prompt: |
-        Fetch CodeQL database for the {{ INPUTS_repo_nwo }} repository for the
+        Fetch CodeQL database for the {{ inputs.repo_nwo }} repository for the
         JavaScript language.
 
         You are auditing code using the previously fetched

--- a/src/seclab_taskflows/taskflows/audit/remote_sources_local.yaml
+++ b/src/seclab_taskflows/taskflows/audit/remote_sources_local.yaml
@@ -3,8 +3,7 @@
 
 seclab-taskflow-agent:
   filetype: taskflow
-  version: 1
-
+  version: "1.0"
 model_config: seclab_taskflows.configs.model_config_codeql_python
 
 globals:
@@ -18,7 +17,7 @@ taskflow:
       agents:
         - seclab_taskflow_agent.personalities.assistant
       user_prompt: |
-        Clear the memory cache and clear the codeql_sqlite database for repo {{ GLOBALS_repo }}.
+        Clear the memory cache and clear the codeql_sqlite database for repo {{ globals.repo }}.
       toolboxes:
         - seclab_taskflow_agent.toolboxes.memcache
         - seclab_taskflows.toolboxes.codeql_python
@@ -29,7 +28,7 @@ taskflow:
       agents:
         - seclab_taskflow_agent.personalities.assistant
       user_prompt: |
-        For the repo {{ GLOBALS_repo }} fetch the Python CodeQL database and find all remote flow sources using CodeQL.
+        For the repo {{ globals.repo }} fetch the Python CodeQL database and find all remote flow sources using CodeQL.
       toolboxes:
         - seclab_taskflows.toolboxes.gh_code_scanning
         - seclab_taskflows.toolboxes.codeql_python
@@ -40,7 +39,7 @@ taskflow:
       agents:
         - seclab_taskflow_agent.personalities.assistant
       user_prompt: |
-        Fetch the zipball of the repository {{ GLOBALS_repo }}.
+        Fetch the zipball of the repository {{ globals.repo }}.
       toolboxes:
         - seclab_taskflows.toolboxes.local_gh_resources
   - task:
@@ -50,7 +49,7 @@ taskflow:
       agents:
         - seclab_taskflow_agent.personalities.assistant
       user_prompt: |
-        Fetch the sources from the repo {{ GLOBALS_repo }}.
+        Fetch the sources from the repo {{ globals.repo }}.
       toolboxes:
         - seclab_taskflows.toolboxes.codeql_python
   - task:
@@ -63,7 +62,7 @@ taskflow:
       agents:
         - seclab_taskflows.personalities.auditor
       user_prompt: |
-        The source is a {{ RESULT_source_type }} in {{ RESULT_repo }} in the location {{ RESULT_source_location }} on line {{ RESULT_line }}.
+        The source is a {{ result.source_type }} in {{ result.repo }} in the location {{ result.source_location }} on line {{ result.line }}.
         If the source is in a folder relating to tests or demo code, skip the analysis and update the source entry in the codeql_sqlite database indicating it is not relevant.
         Analyze what the source endpoint is used for.
         If it is a web endpoint, identify the routing path that reaches this source, HTTP method,
@@ -91,6 +90,6 @@ taskflow:
         - seclab_taskflows.personalities.auditor
       model: code_analysis
       user_prompt: |
-        Fetch the sources of the repo {{ GLOBALS_repo }} and give a summary of the notes.
+        Fetch the sources of the repo {{ globals.repo }} and give a summary of the notes.
       toolboxes:
         - seclab_taskflows.toolboxes.codeql_python

--- a/src/seclab_taskflows/toolboxes/codeql_python.yaml
+++ b/src/seclab_taskflows/toolboxes/codeql_python.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 seclab-taskflow-agent:
-  version: 1
+  version: "1.0"
   filetype: toolbox
 
 server_params:
@@ -12,13 +12,13 @@ server_params:
   command: python
   args: ["-m", "seclab_taskflows.mcp_servers.codeql_python.mcp_server"]
   env:
-    CODEQL_DBS_BASE_PATH: "{{ env CODEQL_DBS_BASE_PATH }}"
+    CODEQL_DBS_BASE_PATH: "{{ env('CODEQL_DBS_BASE_PATH') }}"
     # prevent git repo operations on gh codeql executions
     GH_NO_UPDATE_NOTIFIER: "Disable"
     GH_NO_EXTENSION_UPDATE_NOTIFIER: "Disable"
-    CODEQL_CLI: "{{ env CODEQL_CLI }}"
-    DATA_DIR: "{{ env DATA_DIR }}"
-    LOG_DIR: "{{ env LOG_DIR }}"
+    CODEQL_CLI: "{{ env('CODEQL_CLI') }}"
+    DATA_DIR: "{{ env('DATA_DIR') }}"
+    LOG_DIR: "{{ env('LOG_DIR') }}"
 server_prompt: |
   ## CodeQL Supported Programming Languages
 

--- a/src/seclab_taskflows/toolboxes/gh_actions.yaml
+++ b/src/seclab_taskflows/toolboxes/gh_actions.yaml
@@ -3,13 +3,12 @@
 
 seclab-taskflow-agent:
   filetype: toolbox
-  version: 1
-
+  version: "1.0"
 server_params:
   kind: stdio
   command: python
   args: ["-m", "seclab_taskflows.mcp_servers.gh_actions"]
   env:
-    GH_TOKEN: "{{ env GH_TOKEN }}"
-    ACTIONS_DB_DIR: "{{ env DATA_DIR }}"
-    LOG_DIR: "{{ env LOG_DIR }}"
+    GH_TOKEN: "{{ env('GH_TOKEN') }}"
+    ACTIONS_DB_DIR: "{{ env('DATA_DIR') }}"
+    LOG_DIR: "{{ env('LOG_DIR') }}"

--- a/src/seclab_taskflows/toolboxes/gh_code_scanning.yaml
+++ b/src/seclab_taskflows/toolboxes/gh_code_scanning.yaml
@@ -3,14 +3,13 @@
 
 seclab-taskflow-agent:
   filetype: toolbox
-  version: 1
-
+  version: "1.0"
 server_params:
   kind: stdio
   command: python
   args: ["-m", "seclab_taskflows.mcp_servers.gh_code_scanning"]
   env:
-    GH_TOKEN: "{{ env GH_TOKEN }}"
-    CODEQL_DBS_BASE_PATH: "{{ env CODEQL_DBS_BASE_PATH }}"
-    ALERT_RESULTS_DIR: "{{ env DATA_DIR }}"
-    LOG_DIR: "{{ env LOG_DIR }}"
+    GH_TOKEN: "{{ env('GH_TOKEN') }}"
+    CODEQL_DBS_BASE_PATH: "{{ env('CODEQL_DBS_BASE_PATH') }}"
+    ALERT_RESULTS_DIR: "{{ env('DATA_DIR') }}"
+    LOG_DIR: "{{ env('LOG_DIR') }}"

--- a/src/seclab_taskflows/toolboxes/gh_file_viewer.yaml
+++ b/src/seclab_taskflows/toolboxes/gh_file_viewer.yaml
@@ -3,13 +3,12 @@
 
 seclab-taskflow-agent:
   filetype: toolbox
-  version: 1
-
+  version: "1.0"
 server_params:
   kind: stdio
   command: python
   args: ["-m", "seclab_taskflows.mcp_servers.gh_file_viewer"]
   env:
-    GH_TOKEN: "{{ env GH_TOKEN }}"
-    SEARCH_RESULTS_DIR: "{{ env DATA_DIR }}"
-    LOG_DIR: "{{ env LOG_DIR }}"
+    GH_TOKEN: "{{ env('GH_TOKEN') }}"
+    SEARCH_RESULTS_DIR: "{{ env('DATA_DIR') }}"
+    LOG_DIR: "{{ env('LOG_DIR') }}"

--- a/src/seclab_taskflows/toolboxes/ghsa.yaml
+++ b/src/seclab_taskflows/toolboxes/ghsa.yaml
@@ -3,12 +3,11 @@
 
 seclab-taskflow-agent:
   filetype: toolbox
-  version: 1
-
+  version: "1.0"
 server_params:
   kind: stdio
   command: python
   args: ["-m", "seclab_taskflows.mcp_servers.ghsa"]
   env:
-    GH_TOKEN: "{{ env GH_TOKEN }}"
-    LOG_DIR: "{{ env LOG_DIR }}"
+    GH_TOKEN: "{{ env('GH_TOKEN') }}"
+    LOG_DIR: "{{ env('LOG_DIR') }}"

--- a/src/seclab_taskflows/toolboxes/local_file_viewer.yaml
+++ b/src/seclab_taskflows/toolboxes/local_file_viewer.yaml
@@ -3,14 +3,13 @@
 
 seclab-taskflow-agent:
   filetype: toolbox
-  version: 1
-
+  version: "1.0"
 server_params:
   kind: stdio
   command: python
   args: ["-m", "seclab_taskflows.mcp_servers.local_file_viewer"]
   env:
-    LOCAL_GH_DIR: "{{ env DATA_DIR }}"
-    LINE_LIMIT_FOR_FETCHING_FILE_CONTENT: "{{ env LINE_LIMIT_FOR_FETCHING_FILE_CONTENT }}"
-    FILE_LIMIT_FOR_LIST_FILES: "{{ env FILE_LIMIT_FOR_LIST_FILES }}"
-    LOG_DIR: "{{ env LOG_DIR }}"
+    LOCAL_GH_DIR: "{{ env('DATA_DIR') }}"
+    LINE_LIMIT_FOR_FETCHING_FILE_CONTENT: "{{ env('LINE_LIMIT_FOR_FETCHING_FILE_CONTENT') }}"
+    FILE_LIMIT_FOR_LIST_FILES: "{{ env('FILE_LIMIT_FOR_LIST_FILES') }}"
+    LOG_DIR: "{{ env('LOG_DIR') }}"

--- a/src/seclab_taskflows/toolboxes/local_gh_resources.yaml
+++ b/src/seclab_taskflows/toolboxes/local_gh_resources.yaml
@@ -3,13 +3,12 @@
 
 seclab-taskflow-agent:
   filetype: toolbox
-  version: 1
-
+  version: "1.0"
 server_params:
   kind: stdio
   command: python
   args: ["-m", "seclab_taskflows.mcp_servers.local_gh_resources"]
   env:
-    GH_TOKEN: "{{ env GH_TOKEN }}"
-    LOCAL_GH_DIR: "{{ env DATA_DIR }}"
-    LOG_DIR: "{{ env LOG_DIR }}"
+    GH_TOKEN: "{{ env('GH_TOKEN') }}"
+    LOCAL_GH_DIR: "{{ env('DATA_DIR') }}"
+    LOG_DIR: "{{ env('LOG_DIR') }}"

--- a/src/seclab_taskflows/toolboxes/repo_context.yaml
+++ b/src/seclab_taskflows/toolboxes/repo_context.yaml
@@ -3,12 +3,11 @@
 
 seclab-taskflow-agent:
   filetype: toolbox
-  version: 1
-
+  version: "1.0"
 server_params:
   kind: stdio
   command: python
   args: ["-m", "seclab_taskflows.mcp_servers.repo_context"]
   env:
-    REPO_CONTEXT_DIR: "{{ env DATA_DIR }}"
-    LOG_DIR: "{{ env LOG_DIR }}"
+    REPO_CONTEXT_DIR: "{{ env('DATA_DIR') }}"
+    LOG_DIR: "{{ env('LOG_DIR') }}"

--- a/src/seclab_taskflows/toolboxes/report_alert_state.yaml
+++ b/src/seclab_taskflows/toolboxes/report_alert_state.yaml
@@ -3,15 +3,14 @@
 
 seclab-taskflow-agent:
   filetype: toolbox
-  version: 1
-
+  version: "1.0"
 server_params:
   kind: stdio
   command: python
   args: ["-m", "seclab_taskflows.mcp_servers.report_alert_state"]
   env:
-    ALERT_RESULTS_DIR: "{{ env DATA_DIR }}"
-    LOG_DIR: "{{ env LOG_DIR }}"
+    ALERT_RESULTS_DIR: "{{ env('DATA_DIR') }}"
+    LOG_DIR: "{{ env('LOG_DIR') }}"
 # the list of tools that you want the framework to confirm with the user before executing
 # use this to guard rail any potentially dangerous functions from MCP servers
 confirm:


### PR DESCRIPTION
Migrate all YAML files to use semver string version format for compatibility with Jinja2 template system.

## Dependencies

This PR depends on GitHubSecurityLab/seclab-taskflow-agent#125 and requires that PR to be merged first.

## Changes

- Migrated all YAML files from integer version to version `"1.0"` string format
- Updated taskflows to use new Jinja2 template syntax where applicable
- Compatible with seclab-taskflow-agent v1.0+ which uses Jinja2 templating

## Migration Details

All files were migrated using the migration script from seclab-taskflow-agent:
```bash
python scripts/migrate_to_jinja2.py /path/to/seclab-taskflows
```

This updates:
- Language version from integer to semver string format (`version: "1.0"`)
- Template syntax from custom format to Jinja2 format
  - `{{ GLOBALS_key }}` → `{{ globals.key }}`
  - `{{ INPUTS_key }}` → `{{ inputs.key }}`
  - `{{ RESULT }}` → `{{ result }}`
  - `{{ env VAR }}` → `{{ env('VAR') }}`
  - `{{ PROMPTS_path }}` → `{% include 'path' %}`