### PR TITLE
Add openFiles configuration for Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -35,6 +35,12 @@
       "settings": {
         "python.useEnvironmentsExtension": true
       }
+    },
+    "codespaces": {
+      "openFiles": [
+        "README.md",
+        ".env"
+      ]
     }
   },
   // Use 'forwardPorts' to make a list of ports inside the container available locally


### PR DESCRIPTION
Open the `.env` file for easier configuration after starting a new codespace.