### PR TITLE
Fix mcp_data_dir instances

### DIFF
--- a/src/seclab_taskflows/mcp_servers/alert_results_models.py
+++ b/src/seclab_taskflows/mcp_servers/alert_results_models.py
@@ -4,6 +4,9 @@
 from sqlalchemy import String, Text, Integer, ForeignKey, Column
 from sqlalchemy.orm import DeclarativeBase, mapped_column, Mapped, relationship
 from typing import Optional
+from seclab_taskflow_agent.path_utils import mcp_data_dir
+
+ALERT_RESULTS_DIR = mcp_data_dir("seclab-taskflows", "report_alert_state", "ALERT_RESULTS_DIR")
 
 
 class Base(DeclarativeBase):

--- a/src/seclab_taskflows/mcp_servers/codeql_python/mcp_server.py
+++ b/src/seclab_taskflows/mcp_servers/codeql_python/mcp_server.py
@@ -21,6 +21,7 @@ from seclab_taskflow_agent.path_utils import mcp_data_dir, log_file_name
 
 from .codeql_sqlite_models import Base, Source
 from ..utils import process_repo
+from ..codeql_utils import CODEQL_DBS_BASE_PATH
 
 logging.basicConfig(
     level=logging.DEBUG,
@@ -30,7 +31,6 @@ logging.basicConfig(
 )
 
 MEMORY = mcp_data_dir("seclab-taskflows", "codeql", "DATA_DIR")
-CODEQL_DBS_BASE_PATH = mcp_data_dir("seclab-taskflows", "codeql", "CODEQL_DBS_BASE_PATH")
 
 mcp = FastMCP("CodeQL-Python")
 

--- a/src/seclab_taskflows/mcp_servers/codeql_utils.py
+++ b/src/seclab_taskflows/mcp_servers/codeql_utils.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2025 GitHub
+# SPDX-License-Identifier: MIT
+
+from seclab_taskflow_agent.path_utils import mcp_data_dir
+
+CODEQL_DBS_BASE_PATH = mcp_data_dir("seclab-taskflows", "codeql", "CODEQL_DBS_BASE_PATH")

--- a/src/seclab_taskflows/mcp_servers/gh_code_scanning.py
+++ b/src/seclab_taskflows/mcp_servers/gh_code_scanning.py
@@ -14,9 +14,10 @@ from pathlib import Path
 import zipfile
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
-from seclab_taskflow_agent.path_utils import mcp_data_dir, log_file_name
+from seclab_taskflow_agent.path_utils import log_file_name
 
-from .alert_results_models import AlertResults, AlertFlowGraph, Base
+from .alert_results_models import AlertResults, AlertFlowGraph, Base, ALERT_RESULTS_DIR
+from .codeql_utils import CODEQL_DBS_BASE_PATH
 
 logging.basicConfig(
     level=logging.DEBUG,
@@ -28,9 +29,6 @@ logging.basicConfig(
 mcp = FastMCP("GitHubCodeScanning")
 
 GH_TOKEN = os.getenv("GH_TOKEN", default="")
-
-CODEQL_DBS_BASE_PATH = mcp_data_dir("seclab-taskflows", "codeql", "CODEQL_DBS_BASE_PATH")
-ALERT_RESULTS_DIR = mcp_data_dir("seclab-taskflows", "gh_code_scanning", "ALERT_RESULTS_DIR")
 
 
 def parse_alert(alert: dict) -> dict:

--- a/src/seclab_taskflows/mcp_servers/local_file_viewer.py
+++ b/src/seclab_taskflows/mcp_servers/local_file_viewer.py
@@ -10,8 +10,8 @@ import os
 from pathlib import Path
 import aiofiles
 import zipfile
-import tempfile
-from seclab_taskflow_agent.path_utils import mcp_data_dir, log_file_name
+from seclab_taskflow_agent.path_utils import log_file_name
+from .local_gh_resources import LOCAL_GH_DIR
 
 logging.basicConfig(
     level=logging.DEBUG,
@@ -21,8 +21,6 @@ logging.basicConfig(
 )
 
 mcp = FastMCP("LocalFileViewer")
-
-LOCAL_GH_DIR = mcp_data_dir("seclab-taskflows", "local_file_viewer", "LOCAL_GH_DIR")
 
 LINE_LIMIT_FOR_FETCHING_FILE_CONTENT = int(os.getenv("LINE_LIMIT_FOR_FETCHING_FILE_CONTENT", default=1000))
 

--- a/src/seclab_taskflows/mcp_servers/report_alert_state.py
+++ b/src/seclab_taskflows/mcp_servers/report_alert_state.py
@@ -10,9 +10,9 @@ from typing import Any
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 from pydantic import Field
-from seclab_taskflow_agent.path_utils import mcp_data_dir, log_file_name
+from seclab_taskflow_agent.path_utils import log_file_name
 
-from .alert_results_models import AlertResults, AlertFlowGraph, Base
+from .alert_results_models import AlertResults, AlertFlowGraph, Base, ALERT_RESULTS_DIR
 
 logging.basicConfig(
     level=logging.DEBUG,
@@ -59,9 +59,6 @@ def remove_line_numbers(location: str) -> str:
         return location
     # Keep the first part (file path) and the last two parts (col:col)
     return ":".join(parts[:-4])
-
-
-MEMORY = mcp_data_dir("seclab-taskflows", "report_alert_state", "ALERT_RESULTS_DIR")
 
 
 class ReportAlertStateBackend:
@@ -296,7 +293,7 @@ class ReportAlertStateBackend:
 
 mcp = FastMCP("ReportAlertState")
 
-backend = ReportAlertStateBackend(MEMORY)
+backend = ReportAlertStateBackend(ALERT_RESULTS_DIR)
 
 
 def process_repo(repo):


### PR DESCRIPTION
I noticed that `local_file_viewer.py` wasn't working because it was looking for the zip file in the wrong directory. It's supposed to use the same directory as `local_gh_resources.py`. This bug doesn't happen if you explicitly set the `LOCAL_GH_DIR` environment variable, but it's a problem if you let `mcp_data_dir` use the default location.

`ALERT_RESULTS_DIR` has the same bug.

I accidentally introduced this bug in #11.