### PR TITLE
Open README.md in the editor after creating a codespace

### DIFF
--- a/.devcontainer/post-attach.sh
+++ b/.devcontainer/post-attach.sh
@@ -17,6 +17,7 @@ if [ ! -f .env ]; then
     echo "📝 Creating .env template..."
     cp .devcontainer/env-default .env || { echo "Error creating .env"; exit 1; }
     code .env || echo "ℹ️ Unable to open .env in VS Code. Please open and review the .env file manually."
+    code README.md
     echo "⚠️  Defaults can be changed by editing the auto-generated .env file."
 fi
 


### PR DESCRIPTION
I previously added code to automatically open `.env` in the editor. But I think that the focus should be still be on `README.md`. Hopefully this will bring `README.md` back to the front.