### PR TITLE
Show markdown files as previews

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -36,7 +36,7 @@
       "settings": {
         "python.useEnvironmentsExtension": true,
         "workbench.editorAssociations": {
-            "*.md": "vscode.markdown.preview.editor"
+          "*.md": "vscode.markdown.preview.editor"
         }
       }
     }


### PR DESCRIPTION
Open markdown files in preview mode, making them easier to read. I also removed the automatic open of `README.md` because it's done better by `post-attach.sh`.