### PR TITLE
Split publish workflows into two jobs

### DIFF
--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -6,8 +6,40 @@ on:
       - v[0-9]+.[0-9]+.[0-9]+
 
 jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+
+
+    permissions:
+      contents: read
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+
+    - name: Set up Python
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: "3.14"
+
+    - name: Install Hatch
+      run: pip install --upgrade hatch
+
+    - name: Build the wheel
+      run: python3 -m hatch build
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: python-package-distributions
+        path: ./dist/
+
   publish:
-    name: Build
+    name: Publish to PyPI
+    needs: build
     runs-on: ubuntu-latest
 
     # This environment is required as an input to pypa/gh-action-pypi-publish
@@ -24,35 +56,19 @@ jobs:
       attestations: write  # For artifact attestation
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+    - name: Download distribution artifacts
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
-        persist-credentials: false
-
-    - name: Set up Python
-      uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
-      with:
-        python-version: "3.14"
-
-    - name: Install Hatch
-      run: pip install --upgrade hatch
-
-    - name: Build the wheel
-      run: python3 -m hatch build
+        name: python-package-distributions
+        path: ./dist/
 
     - name: Attest build provenance
-      uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
+      uses: actions/attest@v4.1.0 # immutable release
       with:
         subject-path: ./dist/*
 
-    - name: Upload artifacts
-      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
-      with:
-        name: python-package-distributions
-        path: dist/
-
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
       with:
         verbose: true
 

--- a/.github/workflows/publish-to-testpypi.yaml
+++ b/.github/workflows/publish-to-testpypi.yaml
@@ -1,33 +1,25 @@
-name: Publish to TestPyPI
+name: Publish Pre-Release to TestPyPI
 
 on: workflow_dispatch
 
 jobs:
-  publish:
-    name: Build
+  build:
+    name: Build distribution
     runs-on: ubuntu-latest
-
-    # This environment is required as an input to pypa/gh-action-pypi-publish
-    environment:
-      name: testpypi
-      url: https://test.pypi.org/p/seclab-taskflows
-
-    env:
-      GITHUB_REPO: ${{ github.repository }}
+    outputs:
+      release_name: ${{ steps.create_version_number.outputs.RELEASE_NAME }}
 
     permissions:
-      contents: write
-      id-token: write  # For trusted publishing
-      attestations: write  # For artifact attestation
+      contents: read
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
 
     - name: Set up Python
-      uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: "3.14"
 
@@ -52,19 +44,44 @@ jobs:
     - name: Build the wheel
       run: python3 -m hatch build
 
+    - name: Upload artifacts
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: python-package-distributions
+        path: ./dist/
+
+  publish:
+    name: Publish to TestPyPI
+    needs: build
+    runs-on: ubuntu-latest
+
+    # This environment is required as an input to pypa/gh-action-pypi-publish
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/seclab-taskflows
+
+    env:
+      GITHUB_REPO: ${{ github.repository }}
+
+    permissions:
+      contents: write
+      id-token: write  # For trusted publishing
+      attestations: write  # For artifact attestation
+
+    steps:
+    - name: Download distribution artifacts
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: python-package-distributions
+        path: ./dist/
+
     - name: Attest build provenance
-      uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
+      uses: actions/attest@v4.1.0 # immutable release
       with:
         subject-path: ./dist/*
 
-    - name: Upload artifacts
-      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
-      with:
-        name: python-package-distributions
-        path: dist/
-
     - name: Publish to TestPyPI
-      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
       with:
         repository-url: https://test.pypi.org/legacy/
         verbose: true
@@ -72,5 +89,5 @@ jobs:
     - name: Create GitHub Release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        RELEASE_NAME: ${{ steps.create_version_number.outputs.RELEASE_NAME }}
+        RELEASE_NAME: ${{ needs.build.outputs.release_name }}
       run: gh release create $RELEASE_NAME dist/* --repo $GITHUB_REPO --prerelease --generate-notes


### PR DESCRIPTION
Apply the same changes as what we already did in [seclab-taskflow-agent](https://github.com/GitHubSecurityLab/seclab-taskflow-agent/) (see https://github.com/GitHubSecurityLab/seclab-taskflow-agent/pull/246).